### PR TITLE
references doesn't appear in mysql 5.6.26 (and a possible solution)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,9 @@ AutoSequelize.prototype.run = function(options, callback) {
           // map sqlite's PRAGMA results
           ref = Sequelize.Utils._.assign(ref, {
             source_table: table,
-            source_column: ref.from,
-            target_table: ref.table,
-            target_column: ref.to
+            source_column: ref.source_column,
+            target_table: ref.target_table,
+            target_column: ref.target_column
           });
 
           if (ref.source_column && ref.target_column) {


### PR DESCRIPTION
In my pc, when I created the models, the references doesn't appear (foreign key).
I use:
mysql  Ver 14.14 Distrib 5.6.26, for Win64 (x86_64)
Last sequelize-auto from npm (version 0.2.1)

After a whie, i fix for my case, changing the lines after 44 in lib/index.js to:
````js
          ref = Sequelize.Utils._.assign(ref, {
            source_table: table,
            source_column: ref.source_column,
            target_table: ref.target_table,
            target_column: ref.target_column
          });
````

I only changed the 3 lines after source_table: table,
It work in my PC, should work on other DBMS or OS's, but i didn't tested.