### PR TITLE
Fix Model for Singular Table Names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,9 +204,10 @@ AutoSequelize.prototype.run = function(options, callback) {
 
           //conditionally add additional options to tag on to orm objects
           var hasadditional = typeof options.additional === "object" && Object.keys(options.additional).length > 0;
-          if(hasadditional) {
+          if(hasadditional || options.tableName) {
 
-            text[table]  += ", {\n";
+            text[table] += ", {\n";
+            text[table] += spaces + spaces  + "tableName: '" + table + "',\n";
             for(var additional in options.additional) {
               text[table] += spaces + spaces + additional + ": " + options.additional[additional] + ",\n";
             }


### PR DESCRIPTION
When you have a table with singular name, as Sequelize automatically pluralise the name, it doesn't work properly...

Also, this is a old known bug (https://github.com/sequelize/sequelize-auto/issues/7) 