### PR TITLE
Fix Generation when Private Key is a fkey Too

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,6 @@ AutoSequelize.prototype.run = function(options, callback) {
             var foreignKey = _foreignKeys[table] && _foreignKeys[table][field] ? _foreignKeys[table][field] : null
             if (Sequelize.Utils._.isObject(foreignKey)) {
               _tables[table][field].foreignKey = foreignKey
-              _tables[table][field].primaryKey = false
             }
 
             // column's attributes


### PR DESCRIPTION
I don't see a strong reason for this line i'm removing...

I have a pivot table, which doesn't have an `id` column, i have two relations that are both, private key and foreign key:

````
CREATE TABLE `job_type_user` (
  `job_type_id` int(10) unsigned NOT NULL,
  `user_id` int(10) unsigned NOT NULL,
  `created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  PRIMARY KEY (`job_type_id`,`user_id`),
  KEY `job_type_user_job_type_id_index` (`job_type_id`),
  KEY `job_type_user_user_id_index` (`user_id`),
  CONSTRAINT `job_type_user_job_type_id_foreign` FOREIGN KEY (`job_type_id`) REFERENCES `job_types` (`id`) ON DELETE CASCADE,
  CONSTRAINT `job_type_user_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
````