### PR TITLE
Add option for preserving table names always

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,16 @@ AutoSequelize.prototype.run = function(options, callback) {
       text[table] += "\n" + spaces + "}";
 
       function addAdditionalOption(value, key) {
-        text[table] += spaces + spaces + key + ": " + value + ",\n";
+        if (key === 'name') {
+          // name: true - preserve table name always
+          text[table] += spaces + spaces + "name: {\n";
+          text[table] += spaces + spaces + spaces + "singular" + ": '" + table + "',\n";
+          text[table] += spaces + spaces + spaces + "plural" + ": '" + table + "'\n";
+          text[table] += spaces + spaces + "},\n";
+        }
+        else {
+          text[table] += spaces + spaces + key + ": " + value + ",\n";
+        }
       }
 
       //resume normal output


### PR DESCRIPTION
:wave: I'm using this module to generate a bunch of models, but I need to know the exact table name always because I'm generating the sequelize calls in my layer.

So I added the `name: true` option, kind of funky, but can't think of better way to add it:

```json
{
  "additional": {
    "name": true
  }
}
```

```bash
./node_modules/.bin/sequelize-auto \
  --host localhost \
  --database data-types \
  --user root \
  --pass karamba \
  --port 3300 \
  --dialect mysql \
  --config /path/to/models.json \
  --output /path/to/models/
```

```js
/* jshint indent: 2 */

module.exports = function(sequelize, DataTypes) {
  return sequelize.define('mtm', {
    id: {
      type: DataTypes.INTEGER(11),
      allowNull: false,
      primaryKey: true,
      autoIncrement: true
    },
    name1: {
      type: DataTypes.STRING,
      allowNull: false
    },
    name2: {
      type: DataTypes.INTEGER(11),
      allowNull: true
    }
  }, {
    tableName: 'mtm',
    name: {
      singular: 'mtm',
      plural: 'mtm'
    },
    freezeTableName: true
  });
};
```