### PR TITLE
Fix primaryKey when field is foreignKey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,9 @@ AutoSequelize.prototype.run = function(options, callback) {
           source_table: table,
           source_column: sourceColumn,
           target_table: targetTable,
-          target_column: targetColumn
+          target_column: targetColumn,
+          isForeignKey : isForeignKey,
+          isPrimaryKey: isPrimaryKey
         });
 
         if (isForeignKey || isPrimaryKey) {
@@ -137,7 +139,7 @@ AutoSequelize.prototype.run = function(options, callback) {
             }
           }
           else if (attr === "primaryKey") {
-            if (_tables[table][field][attr] === true)
+             if (_tables[table][field][attr] === true && _tables[table][field].hasOwnProperty('foreignKey') && !!_tables[table][field].foreignKey.isPrimaryKey){
               text[table] += spaces + spaces + spaces + "primaryKey: true";
             else return true
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,7 @@ AutoSequelize.prototype.run = function(options, callback) {
             }
           }
           else if (attr === "primaryKey") {
-             if (_tables[table][field][attr] === true && _tables[table][field].hasOwnProperty('foreignKey') && !!_tables[table][field].foreignKey.isPrimaryKey){
+             if (_tables[table][field][attr] === true && _tables[table][field].hasOwnProperty('foreignKey') && !!_tables[table][field].foreignKey.isPrimaryKey)
               text[table] += spaces + spaces + spaces + "primaryKey: true";
             else return true
           }


### PR DESCRIPTION
self.queryInterface.describeTable(table) return primaryKey = true when field is a foreignKey
I don't know why but my patch fix it