### PR TITLE
Ignore timestamps

### DIFF
--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -4,7 +4,7 @@ var sequelizeAuto = require('../')
   , path = require('path');
 
 var argv = require('optimist')
-  .usage('Usage: sequelize-auto -h <host> -d <database> -u <user> -x [password] -p [port]  --dialect [dialect] -c [/path/to/config] -o [/path/to/models] -t [tableName]')
+  .usage('Usage: sequelize-auto -h <host> -d <database> -u <user> -x [password] -p [port]  --dialect [dialect] -c [/path/to/config] -o [/path/to/models] -t [tableName] -i [true/false]')
   .demand(['h', 'd'])
   .alias('h', 'host')
   .alias('d', 'database')
@@ -16,6 +16,7 @@ var argv = require('optimist')
   .alias('e', 'dialect')
   .alias('a', 'additional')
   .alias('t', 'tables')
+  .alias('i', 'timestamps')
   .describe('h', 'IP/Hostname for the database.')
   .describe('d', 'Database name.')
   .describe('u', 'Username for database.')
@@ -26,6 +27,7 @@ var argv = require('optimist')
   .describe('e', 'The dialect/engine that you\'re using: postgres, mysql, sqlite')
   .describe('a', 'Path to a json file containing model definitions (for all tables) which are to be defined within a model\'s configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration')
   .describe('t', 'Comma-separated names of tables to import')
+  .describe('i', 'Ignore timestamps (createdAt, updatedAt and deletedAt), if you set to false, sequelize not reconize special field and it not auto fill fields')
   .argv;
 
 var configFile = {};
@@ -46,11 +48,12 @@ configFile.port = argv.p || configFile.port || 3306;
 configFile.host = argv.h || configFile.host || 'localhost';
 configFile.storage = argv.d;
 configFile.tables = configFile.tables || (argv.t && argv.t.split(',')) || null;
+configFile.ignoreTimestamps = argv.i || true;
 
 var auto = new sequelizeAuto(argv.d, argv.u, (!! argv.x ? ('' + argv.x) : null), configFile);
 var dir = argv.o || path.resolve(process.cwd() + '/models');
 
-auto.run({spaces: true, indentation: 2, directory: dir, tables : configFile.tables, additional : additional}, function(err){
+auto.run({spaces: true, indentation: 2, directory: dir, tables : configFile.tables, additional : additional, ignoreTimestamps : configFile.ignoreTimestamps}, function(err){
   if (err) throw err;
   console.log('Done!');
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,8 +28,9 @@ AutoSequelize.prototype.run = function(options, callback) {
   options.spaces = options.spaces || false;
   options.indentation = options.indentation || 1;
   options.directory = options.directory || './models';
-  options.additional = options.additional || {}
-  options.additional.freezeTableName = ! _.isUndefined(options.additional.freezeTableName) ? options.additional.freezeTableName : true
+  options.additional = options.additional || {};
+  options.additional.freezeTableName = ! _.isUndefined(options.additional.freezeTableName) ? options.additional.freezeTableName : true;
+  options.ignoreTimestamps = options.ignoreTimestamps || true;
 
   self.options = options;
 
@@ -101,6 +102,11 @@ AutoSequelize.prototype.run = function(options, callback) {
       text[table] += spaces + "return sequelize.define('" + table + "', {\n";
 
       _.each(fields, function(field, i){
+      	
+      	if (!!options.ignoreTimestamps && ('createdAt,updatedAt,deletedAt'.indexOf(field) !== -1)) {
+      		return;
+      	}
+      	
         // Find foreign key
         var foreignKey = _foreignKeys[table] && _foreignKeys[table][field] ? _foreignKeys[table][field] : null
         if (_.isObject(foreignKey)) {


### PR DESCRIPTION
Use to ignore generation of createdAt updatedAt and deletedAt, because sequelize create it automatically if we set timestamps=true in sequelize model definition