### PR TITLE
Add mysql fields comments suport

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,34 @@ AutoSequelize.prototype.run = function(options, callback) {
   }
 
   function mapTable(table, _callback){
-    self.queryInterface.describeTable(table).then(function(fields) {
+    if (self.sequelize.options.dialect !== 'mysql') {
+      self.queryInterface.describeTable(table).then(function(fields) {
+        _tables[table] = fields
+        _callback(null);
+      }, _callback);
+      return;
+    }
+    self.queryInterface.sequelize.query("SHOW FULL COLUMNS FROM `" + table + "`",
+        {type: self.sequelize.QueryTypes.SELECT, raw: true}).then(function(columns) {
+      var schema = {};
+      var typeFilter = function(column) {
+        if ( _.startsWith(column, 'enum')) {
+          return column.replace('enum', 'ENUM');
+        } else {
+          return column.toUpperCase();
+        }
+      };
+      _.each(columns, function(column) {
+        schema[column['Field']] = {
+          'allowNull': column['Null'] === 'YES',
+          'defaultValue': column['Default'],
+          'primaryKey': column['Key'] === 'PRI',
+          'type': typeFilter(column['Type']),
+          'comment': column['Comment']
+        }
+      });
+      return schema;
+    }).then(function(fields) {
       _tables[table] = fields
       _callback(null);
     }, _callback);
@@ -161,7 +188,9 @@ AutoSequelize.prototype.run = function(options, callback) {
             }
           }
           else if (attr === "type" && _tables[table][field][attr].indexOf('ENUM') === 0) {
-            text[table] += spaces + spaces + spaces + attr + ": DataTypes." + _tables[table][field][attr];
+            text[ table ] += spaces + spaces + spaces + attr + ": DataTypes." + _tables[ table ][ field ][ attr ];
+          } else if (attr === 'comment') {
+              text[table] += spaces + spaces + spaces + attr + ": '" + _tables[table][field][attr].replace(/\n/g, " ") + "'";
           } else {
             var _attr = (_tables[table][field][attr] || '').toLowerCase();
             var val = "'" + _tables[table][field][attr] + "'";


### PR DESCRIPTION
Since `queryInterface.describeTable` not return comments, use `SHOW FULL COLUMNS FROM xxx` instead of `DESCRIBE xxx` for mysql to get schema comments.
