### PR TITLE
fix for issues #57 - _.contains is not a function

### DIFF
--- a/lib/dialects/index.js
+++ b/lib/dialects/index.js
@@ -127,8 +127,8 @@ exports.postgres = {
   isSerialKey: function(record) {
     return record && exports.postgres.isPrimaryKey(record) && (_.isNull(record.extra) || (record.extra &&
           _.startsWith(record.extra, 'nextval')
-        && _.contains(record.extra, '_seq')
-        && _.contains(record.extra, '::regclass')));
+        && _.includes(record.extra, '_seq')
+        && _.includes(record.extra, '::regclass')));
   }
 }
 


### PR DESCRIPTION
*sequelize* changed lodash to v4.1.0 which removed ```_.contains``` and now it named as ```_.includes```