### PR TITLE
mssql dialect fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ AutoSequelize.prototype.run = function(options, callback) {
   self.options = options;
 
   this.queryInterface.showAllTables().then(function (__tables) {
+    if(self.sequelize.options.dialect == 'mssql') __tables = _.map(__tables, 'tableName');
     tables = options.tables ? _.intersection(__tables, options.tables) : __tables;
     async.each(tables, mapForeignKeys, mapTables)
   });


### PR DESCRIPTION
Sequelize query showAllTables() for mssql dialect returns an array of objects {tableName, schema}, while expecting array of strings.