### PR TITLE
On a "legacy" mysql table where bit columns are used, the following i…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,6 +169,11 @@ AutoSequelize.prototype.run = function(callback) {
 
             if (isSerialKey) return true
 
+            //mySql Bit fix
+            if (self.tables[table][field].type.toLowerCase() == 'bit(1)') {
+              val_text = defaultVal == "b'1'" ? 1 : 0;
+            }
+
             if (_.isString(defaultVal)) {
               val_text = "'" + val_text + "'"
             }
@@ -183,7 +188,7 @@ AutoSequelize.prototype.run = function(callback) {
           } else {
             var _attr = (self.tables[table][field][attr] || '').toLowerCase();
             var val = "'" + self.tables[table][field][attr] + "'";
-            if (_attr === "tinyint(1)" || _attr === "boolean") {
+            if (_attr === "tinyint(1)" || _attr === "boolean" || _attr === "bit(1)") {
               val = 'DataTypes.BOOLEAN';
             }
             else if (_attr.match(/^(smallint|mediumint|tinyint|int)/)) {


### PR DESCRIPTION
…s generated:

IS_ENABLED: {
  type: 'BIT(1)',
  allowNull: true,
  defaultValue: 'b'1''
},

This fix changes the output to:

IS_ENABLED: {
  type: DataTypes.BOOLEAN,
  allowNull: true,
  defaultValue: '1'
},