### PR TITLE
convert CHAR as Datatypes.CHAR

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,6 +215,10 @@ AutoSequelize.prototype.run = function(callback) {
             else if (_attr.match(/^string|varchar|varying|nvarchar/)) {
               val = 'DataTypes.STRING';
             }
+            else if (_attr.match(/^char/)) {
+              var length = _attr.match(/\(\d+\)/);
+              val = 'DataTypes.CHAR' + (!  _.isNull(length) ? length : '');
+            }
             else if (_attr.match(/text|ntext$/)) {
               val = 'DataTypes.TEXT';
             }


### PR DESCRIPTION
Adding CHAR conversion to Datatypes.CHAR

Previously, CHAR fields were shown as "CHAR" (string) and not as "Datatypes.CHAR". 
Without this change the sequelize-graphql will not be able to convert it.