### PR TITLE
fix bug for mssql

### DIFF
--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -56,7 +56,7 @@ configFile.host = argv.h || configFile.host || 'localhost';
 configFile.storage = argv.d;
 configFile.tables = configFile.tables || (argv.t && argv.t.split(',')) || null;
 
-if (configFile.dialect.toLowerCase() === 'mssql' && config.port === 3306)
+if (configFile.dialect.toLowerCase() === 'mssql' && configFile.port === 3306)
     configFile.port = 1433; // default port for MSSQL Server is 1433, not 3306
 
 var auto = new sequelizeAuto(argv.d, argv.u, (!! argv.x ? ('' + argv.x) : null), configFile);


### PR DESCRIPTION
Attempting to run on Windows 10 with Node v4.4.4 I received the error "config is not defined" using the following two commands

sequelize-auto -o "./models" -d mydb -h xxx.xxx.xxx.xxx -u myuser -p 1433 -x
 mypassword -e mssql

sequelize-auto -o "./models" -d mydb -h xxx.xxx.xxx.xxx -u myuser -p 1433 -x mypassword -e mssql -c "c:\source\sequelize-work\config\config.json"

The full error points to a bug in line 59 of sequelize-auto

ReferenceError: config is not defined
    at Object.<anonymous> (C:\Users\xxxxxx\AppData\Roaming\npm\node_modules\sequelize-auto\bin\sequelize-auto:59:53)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3

