### PR TITLE
Add camel case option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Example for MSSQL
 
 ## Usage
 
-    [node] sequelize-auto -h <host> -d <database> -u <user> -x [password] -p [port]  --dialect [dialect] -c [/path/to/config] -o [/path/to/models] -t [tableName]
+    [node] sequelize-auto -h <host> -d <database> -u <user> -x [password] -p [port]  --dialect [dialect] -c [/path/to/config] -o [/path/to/models] -t [tableName] -C
 
     Options:
       -h, --host        IP/Hostname for the database.   [required]
@@ -43,6 +43,7 @@ Example for MSSQL
       -e, --dialect     The dialect/engine that you're using: postgres, mysql, sqlite
       -a, --additional  Path to a json file containing model definitions (for all tables) which are to be defined within a model's configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration
       -t, --tables      Comma-separated names of tables to import
+      -C, --camel       Use camel case to name models and fields
 
 
 ## Example

--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -16,6 +16,7 @@ var argv = require('optimist')
   .alias('e', 'dialect')
   .alias('a', 'additional')
   .alias('t', 'tables')
+  .alias('C', 'camel')
   .describe('h', 'IP/Hostname for the database.')
   .describe('d', 'Database name.')
   .describe('u', 'Username for database.')
@@ -26,6 +27,7 @@ var argv = require('optimist')
   .describe('e', 'The dialect/engine that you\'re using: postgres, mysql, sqlite, mssql')
   .describe('a', 'Path to a json file containing model definitions (for all tables) which are to be defined within a model\'s configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration')
   .describe('t', 'Comma-separated names of tables to import')
+  .describe('C', 'Use camel case to name models and fields')
   .argv;
 
 var dir = argv.o || path.resolve(process.cwd() + '/models');
@@ -55,6 +57,7 @@ configFile.port = argv.p || configFile.port || 3306;
 configFile.host = argv.h || configFile.host || 'localhost';
 configFile.storage = argv.d;
 configFile.tables = configFile.tables || (argv.t && argv.t.split(',')) || null;
+configFile.camelCase = !!argv.C;
 
 if (configFile.dialect.toLowerCase() === 'mssql' && configFile.port === 3306)
     configFile.port = 1433; // default port for MSSQL Server is 1433, not 3306

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,7 +118,8 @@ AutoSequelize.prototype.run = function(callback) {
 
       text[table] = "/* jshint indent: " + self.options.indentation + " */\n\n";
       text[table] += "module.exports = function(sequelize, DataTypes) {\n";
-      text[table] += spaces + "return sequelize.define('" + table + "', {\n";
+      var tableName = self.options.camelCase ? _.camelCase(table) : table;
+      text[table] += spaces + "return sequelize.define('" + tableName + "', {\n";
 
       _.each(fields, function(field, i){
         // Find foreign key
@@ -130,7 +131,8 @@ AutoSequelize.prototype.run = function(callback) {
 
         // column's attributes
         var fieldAttr = _.keys(self.tables[table][field]);
-        text[table] += spaces + spaces + field + ": {\n";
+        var fieldName = self.options.camelCase ? _.camelCase(field) : field;
+        text[table] += spaces + spaces + fieldName + ": {\n";
 
         // Serial key for postgres...
         var defaultVal = self.tables[table][field].defaultValue;
@@ -256,7 +258,9 @@ AutoSequelize.prototype.run = function(callback) {
           text[table] += ",";
           text[table] += "\n";
         });
-
+        if (self.options.camelCase) {
+          text[table] += spaces + spaces + spaces + "field: '" + field + "',\n";
+        }
         // removes the last `,` within the attribute options
         text[table] = text[table].trim().replace(/,+$/, '') + "\n";
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ AutoSequelize.prototype.run = function(callback) {
           } else {
             var _attr = (self.tables[table][field][attr] || '').toLowerCase();
             var val = "'" + self.tables[table][field][attr] + "'";
-            if (_attr === "tinyint(1)" || _attr === "boolean" || _attr === "bit(1)") {
+            if (_attr === "boolean" || _attr === "bit(1)") {
               val = 'DataTypes.BOOLEAN';
             }
             else if (_attr.match(/^(smallint|mediumint|tinyint|int)/)) {


### PR DESCRIPTION
Add `-C` `--camel` option.
You can use this option to covert un-camel-cased table name and field name in the db into camel case name in the model files.

Example:
```
/* jshint indent: 1 */

module.exports = function(sequelize, DataTypes) {
	return sequelize.define('exampleTable', {
		id: {
			type: DataTypes.INTEGER(11),
			allowNull: false,
			primaryKey: true,
			autoIncrement: true,
			field: 'id'
		},
		exampleField: {
			type: DataTypes.INTEGER(11),
			allowNull: false,
			field: 'example_field'
		}
	}, {
		tableName: 'example_table',
		timestamps: false
	});
};

```