### PR TITLE
Set TIME data type instead of DATE

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -226,8 +226,11 @@ AutoSequelize.prototype.run = function(callback) {
             else if (_attr.match(/text|ntext$/)) {
               val = 'DataTypes.TEXT';
             }
-            else if (_attr.match(/^(date|time)/)) {
+            else if (_attr.match(/^(date)/)) {
               val = 'DataTypes.DATE';
+            }
+            else if (_attr.match(/^(time)/)) {
+              val = 'DataTypes.TIME';
             }
             else if (_attr.match(/^(float|float4)/)) {
               val = 'DataTypes.FLOAT';


### PR DESCRIPTION
Sequelize actually have a separate TIME data type. Also trying to set a time value like 03:15:06 throws a validation error when used with the DATE data type.