### PR TITLE
fix: generate mysql timestamp field defaultVal error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,7 +182,8 @@ AutoSequelize.prototype.run = function(callback) {
             }
 
             if (_.isString(defaultVal)) {
-              if (self.tables[table][field].type.toLowerCase().indexOf('date') === 0) {
+              var field_type = self.tables[table][field].type.toLowerCase();
+              if (field_type.indexOf('date') === 0 || field_type.indexOf('timestamp') === 0) {
                 if (_.endsWith(defaultVal, '()')) {
                   val_text = "sequelize.fn('" + defaultVal.replace(/\(\)$/, '') + "')"
                 }


### PR DESCRIPTION
In mysql create a field with  type `timestamp`,  expect  defaultValue is `defaultValue: sequelize.literal('CURRENT_TIMESTAMP')`, but now it is `defaultValue: 'CURRENT_TIMESTAMP'`.  This will fix it.