### PR TITLE
Fixing "too many open files" error by switching to graceful-fs-extra

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var Sequelize = require('sequelize');
 var async = require('async');
-var fs = require('fs');
+var fs = require('graceful-fs-extra');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var dialects = require('./dialects');

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.2.1",
+    "graceful-fs-extra": "^2.0.0",
     "mkdirp": "^0.5.1",
     "sequelize": "^3.20.0",
     "yargs": "^4.7.1"


### PR DESCRIPTION
Just a small fix, that avoids running into the "too many open files" error with large databases.