### PR TITLE
Prevent single-quote explosions in output files.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,7 @@ AutoSequelize.prototype.run = function(callback) {
   this.build(generateText);
 
   function generateText(err) {
+    var quoteWrapper = '"';
     if (err) console.error(err)
 
     async.each(_.keys(self.tables), function(table, _callback){
@@ -144,7 +145,7 @@ AutoSequelize.prototype.run = function(callback) {
 
         // ENUMs for postgres...
         if (self.tables[table][field].type === "USER-DEFINED" && !! self.tables[table][field].special) {
-          self.tables[table][field].type = "ENUM(" + self.tables[table][field].special.map(function(f){ return "'" + f + "'"; }).join(',') + ")";
+          self.tables[table][field].type = "ENUM(" + self.tables[table][field].special.map(function(f){ return quoteWrapper + f + quoteWrapper; }).join(',') + ")";
         }
 
         _.each(fieldAttr, function(attr, x){
@@ -177,7 +178,7 @@ AutoSequelize.prototype.run = function(callback) {
           else if (attr === "defaultValue") {
             if ( self.dialect === 'mssql' &&  defaultVal.toLowerCase() === '(newid())' ) {
               defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
-            }  
+            }
 
             var val_text = defaultVal;
 
@@ -197,10 +198,10 @@ AutoSequelize.prototype.run = function(callback) {
                 else if (_.includes(['current_timestamp', 'current_date', 'current_time', 'localtime', 'localtimestamp'], defaultVal.toLowerCase())) {
                   val_text = "sequelize.literal('" + defaultVal + "')"
                 } else {
-                  val_text = "'" + val_text + "'"
+                  val_text = quoteWrapper + val_text + quoteWrapper
                 }
               } else {
-                val_text = "'" + val_text + "'"
+                val_text = quoteWrapper + val_text + quoteWrapper
               }
             }
             if(defaultVal === null) {
@@ -213,7 +214,7 @@ AutoSequelize.prototype.run = function(callback) {
             text[table] += spaces + spaces + spaces + attr + ": DataTypes." + self.tables[table][field][attr];
           } else {
             var _attr = (self.tables[table][field][attr] || '').toLowerCase();
-            var val = "'" + self.tables[table][field][attr] + "'";
+            var val = quoteWrapper + self.tables[table][field][attr] + quoteWrapper;
             if (_attr === "boolean" || _attr === "bit(1)") {
               val = 'DataTypes.BOOLEAN';
             }


### PR DESCRIPTION
Use double quotes on edge cases of Sequelize types, so no more JS syntax explosions on SQL raw strings with single quotes.

instead of
```
{
		foo: {
			type: 'SET('FIRST-PURCHASE','USER')',
			allowNull: true
		}
}
```
output 
```
{
		foo: {
			type: "SET('FIRST-PURCHASE','USER')",
			allowNull: true
		}
}
```