### PR TITLE
Add "Prevent Write to Disk" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example for MSSQL
       -a, --additional  Path to a json file containing model definitions (for all tables) which are to be defined within a model's configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration
       -t, --tables      Comma-separated names of tables to import
       -C, --camel       Use camel case to name models and fields
-
+      -n, --no-write    Prevent writing the models to disk.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -131,10 +131,11 @@ auto.run(function (err) {
   console.log(auto.foreignKeys); // foreign key list
 });
 
-With options: 
+With options:
 var auto = new SequelizeAuto('database', 'user', 'pass', {
     host: 'localhost',
     dialect: 'mysql'|'mariadb'|'sqlite'|'postgres'|'mssql',
+    directory: false, // prevents the program from writing to disk
     port: 'port',
     additional: {
         timestamps: false

--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -17,6 +17,7 @@ var argv = require('yargs')
   .alias('a', 'additional')
   .alias('t', 'tables')
   .alias('C', 'camel')
+  .alias('n', 'no-write')
   .describe('h', 'IP/Hostname for the database.')
   .describe('d', 'Database name.')
   .describe('u', 'Username for database.')
@@ -28,9 +29,10 @@ var argv = require('yargs')
   .describe('a', 'Path to a json file containing model definitions (for all tables) which are to be defined within a model\'s configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration')
   .describe('t', 'Comma-separated names of tables to import')
   .describe('C', 'Use camel case to name models and fields')
+  .describe('n', 'Prevent writing the models to disk.')
   .argv;
 
-var dir = argv.o || path.resolve(process.cwd() + '/models');
+var dir = !argv.n && (argv.o || path.resolve(process.cwd() + '/models'));
 
 var configFile = {
   spaces: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -316,7 +316,11 @@ AutoSequelize.prototype.run = function(callback) {
       _callback(null);
     }, function(){
       self.sequelize.close();
-      self.write(text, callback);
+
+      if (self.options.directory) {
+        return self.write(text, callback);
+      }
+      return callback(false, text);
     });
   }
 }


### PR DESCRIPTION
This pr adds the option to prevent writing to disk when generating models. Writing to disk is not necessary and consumes resources when using the api programmatically, and (I assume) can cause errors when running on certain cloud services.