### PR TITLE
Cut prefix from table names & tables&skipTables diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ test/models/*.js
 *.swp
 .idea
 .DS_STORE
+.vscode
 node_modules
 npm-debug.log
 *~

--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -19,6 +19,7 @@ var argv = require('yargs')
   .alias('T', 'skip-tables')
   .alias('C', 'camel')
   .alias('n', 'no-write')
+  .alias('P', 'prefixes')
   .describe('h', 'IP/Hostname for the database.')
   .describe('d', 'Database name.')
   .describe('u', 'Username for database.')
@@ -32,6 +33,7 @@ var argv = require('yargs')
   .describe('T', 'Comma-separated names of tables to skip')
   .describe('C', 'Use camel case to name models and fields')
   .describe('n', 'Prevent writing the models to disk.')
+  .describe('P', 'Specify list of prefixes to cut from table names')
   .argv;
 
 var dir = !argv.n && (argv.o || path.resolve(process.cwd() + '/models'));
@@ -63,6 +65,7 @@ configFile.storage = argv.d;
 configFile.tables = configFile.tables || (argv.t && argv.t.split(',')) || null;
 configFile.skipTables = configFile.skipTables || (argv.T && argv.T.split(',')) || null;
 configFile.camelCase = !!argv.C;
+configFile.prefixes = configFile.prefixes || (argv.P && argv.P.split(',')) || null;
 
 if (configFile.dialect.toLowerCase() === 'mssql' && configFile.port === 3306)
     configFile.port = 1433; // default port for MSSQL Server is 1433, not 3306

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,10 @@ AutoSequelize.prototype.build = function(callback) {
 
     var tables;
 
-    if      (self.options.tables)     tables = _.intersection(__tables, self.options.tables)
-    else if (self.options.skipTables) tables = _.difference  (__tables, self.options.skipTables)
-    else                              tables = __tables
+    if      (self.options.skipTables && self.options.tables)  tables = _.difference  (self.options.tables, self.options.skipTables)
+    else if (self.options.skipTables)                         tables = _.difference  (__tables, self.options.skipTables)
+    else if (self.options.tables)                             tables = _.intersection(__tables, self.options.tables)
+    else                                                      tables = __tables
 
     async.each(tables, mapForeignKeys, mapTables)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -342,6 +342,14 @@ AutoSequelize.prototype.write = function(attributes, callback) {
   async.each(tables, createFile, callback)
 
   function createFile(table, _callback){
+    var prefixes = self.options.prefixes
+    if (prefixes) {
+      var regexPattern = Array.isArray(prefixes)
+        ? prefixes.join('|')
+        : prefixes;
+
+      table = table.replace(new RegExp(regexPattern), '');
+    }
     fs.writeFile(path.resolve(path.join(self.options.directory, table + '.js')), attributes[table], _callback);
   }
 }


### PR DESCRIPTION
Hi there.

Sorry that there are two small features at the same PR. I can split that stuff into ind. PRs if needed.
Anyway.

1. `table&skipTables` diff. In some cases it's seem useful to explicitly show which we may import (tables) and what we have to cut (skipTables). I'm talking more about Programmatic API use, i.e. when we have separate script where import conditions are described.

2. Cut prefix. I have to work with databases where structure is almost identical but prefixes differs every time. In that case prefix cutting is quite useful.