### PR TITLE
Fix incorrect foreign key query for postgres

### DIFF
--- a/lib/dialects/index.js
+++ b/lib/dialects/index.js
@@ -113,7 +113,7 @@ exports.postgres = {
       f.relname AS target_table, \
       (SELECT a.attname FROM pg_attribute a WHERE a.attrelid = f.oid AND a.attnum = o.confkey[1] AND a.attisdropped = false) AS target_column, \
       o.contype, \
-      (SELECT d.adsrc AS extra FROM pg_catalog.pg_attribute a LEFT JOIN pg_catalog.pg_attrdef d ON (a.attrelid, a.attnum) = (d.adrelid,  d.adnum) \ WHERE NOT a.attisdropped AND a.attnum > 0 AND a.attrelid = o.conrelid \ LIMIT 1) \
+      (SELECT d.adsrc AS extra FROM pg_catalog.pg_attribute a LEFT JOIN pg_catalog.pg_attrdef d ON (a.attrelid, a.attnum) = (d.adrelid,  d.adnum) \ WHERE NOT a.attisdropped AND a.attnum > 0 AND a.attrelid = o.conrelid AND a.attnum = o.conkey[1]\ LIMIT 1) \
     FROM pg_constraint o \
     LEFT JOIN pg_class c ON c.oid = o.conrelid \
     LEFT JOIN pg_class f ON f.oid = o.confrelid \


### PR DESCRIPTION
This PR fixes issues described in #134 

Previous version was expecting that the "autoIncrement" field was created before any other attributes existed in the table.