### PR TITLE
Fix for 'TIMESTAMP' being generated as DataTypes.Time instead of DataTypes.Date

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -285,7 +285,7 @@ AutoSequelize.prototype.run = function(callback) {
             else if (_attr.match(/text|ntext$/)) {
               val = 'DataTypes.TEXT';
             }
-            else if (_attr.match(/^(date)/)) {
+            else if (_attr.match(/^(date|timestamp)/)) {
               val = 'DataTypes.DATE';
             }
             else if (_attr.match(/^(time)/)) {


### PR DESCRIPTION
#143 