### PR TITLE
Adds eslint to match the model code with the coding standard of the user

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -399,7 +399,8 @@ AutoSequelize.prototype.write = function(attributes, callback) {
   async.each(tables, createFile, callback);
 
   function createFile(table, _callback) {
-    fs.writeFile(path.resolve(path.join(self.options.directory, table + '.js')), attributes[table], _callback);
+    var fileName = self.options.camelCaseForFileName ? _.camelCase(table) : table;
+    fs.writeFile(path.resolve(path.join(self.options.directory, fileName + '.js')), attributes[table], _callback);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var mkdirp = require('mkdirp');
 var dialects = require('./dialects');
 var _ = Sequelize.Utils._;
 var SqlString = require('./sql-string');
+var CLIEngine = require('eslint').CLIEngine;
 
 function AutoSequelize(database, username, password, options) {
   if (options && options.dialect === 'sqlite' && ! options.storage)
@@ -396,7 +397,12 @@ AutoSequelize.prototype.write = function(attributes, callback) {
 
   mkdirp.sync(path.resolve(self.options.directory));
 
-  async.each(tables, createFile, callback);
+  async.each(tables, createFile, !self.options.eslint ? callback : function() {
+    var engine = new CLIEngine({ fix: true });
+    var report = engine.executeOnFiles([self.options.directory]);
+    CLIEngine.outputFixes(report);
+    callback();
+  });
 
   function createFile(table, _callback) {
     var fileName = self.options.camelCaseForFileName ? _.camelCase(table) : table;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.1.5",
+    "eslint": "^3.19.0",
     "graceful-fs-extra": "^2.0.0",
     "mkdirp": "^0.5.1",
     "sequelize": "^3.30.2",


### PR DESCRIPTION
Adds option camelCaseForFileName to make the model file name camel case.
Adds option eslint to match the model code with the coding standard of the user.