### PR TITLE
Fix syntax errors of generated TypeScript code in ts-helper.js

### DIFF
--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -3,10 +3,11 @@
 
 function getModelFileStart(indentation, spaces, tableName) {
     var fileStart = "/* jshint indent: " + indentation + " */\n";
-    fileStart += '// tslint:disable\n'
-    fileStart += 'import sequelize, { DataTypes } from \'sequelize\';\n';
-    fileStart += 'import { ' + tableName + 'Instance, ' + tableName + 'Attribute } from \'./db.d\';\n\n';
-    fileStart += "module.exports = function(sequelize:sequelize.Sequelize, DataTypes:DataTypes) {\n";
+    fileStart += '// tslint:disable\n';
+    fileStart += 'import * as sequelize from \'sequelize\';\n';
+    fileStart += 'import {DataTypes} from \'sequelize\';\n';
+    fileStart += 'import {' + tableName + 'Instance, ' + tableName + 'Attribute} from \'./db\';\n\n';
+    fileStart += "module.exports = function(sequelize: sequelize.Sequelize, DataTypes: DataTypes) {\n";
     fileStart += spaces + 'return sequelize.define<' + tableName + 'Instance, ' + tableName + 'Attribute>(\'' + tableName + '\', {\n';
     return fileStart;
 }
@@ -21,9 +22,9 @@ function generateTableModels(tableNames, isSpaces, indentation) {
 
     function generateImports() {
         var fileTextOutput = '// tslint:disable\n';
-        fileTextOutput += 'import path from \'path\';\n';
-        fileTextOutput += 'import sequelize from \'sequelize\';\n';
-        fileTextOutput += 'import * as def from \'./db.d\';\n\n';
+        fileTextOutput += 'import * as path from \'path\';\n';
+        fileTextOutput += 'import * as sequelize from \'sequelize\';\n';
+        fileTextOutput += 'import * as def from \'./db\';\n\n';
         return fileTextOutput;
     }
 
@@ -52,10 +53,10 @@ function generateTableModels(tableNames, isSpaces, indentation) {
 exports.model = {
     getModelFileStart,
     generateTableModels
-}
+};
 
 function getDefinitionFileStart() {
-    return '// tslint:disable\nimport Sequelize from \'sequelize\';\n\n';
+    return '// tslint:disable\nimport * as Sequelize from \'sequelize\';\n\n';
 }
 
 function getTableDefinition(tsTableDefAttr, tableName) {
@@ -108,4 +109,4 @@ exports.def = {
     getDefinitionFileStart,
     getTableDefinition,
     getMemberDefinition
-}
+};


### PR DESCRIPTION
#176 is very useful but I think it's generating a syntax error code.

## Example:

```typescript
import sequelize from 'sequelize';
```
should change to
```typescript
import * as sequelize from 'sequelize';
```
Found in https://github.com/Microsoft/TypeScript/issues/3337.