### PR TITLE
Fix typescript, add missing option

### DIFF
--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -23,6 +23,7 @@ var argv = require('yargs')
   .alias('n', 'no-write')
   .alias('s', 'schema')
   .alias('z', 'typescript')
+  .alias('f', 'camel-file-name')
   .describe('h', 'IP/Hostname for the database.')
   .describe('d', 'Database name.')
   .describe('u', 'Username for database.')
@@ -38,6 +39,7 @@ var argv = require('yargs')
   .describe('n', 'Prevent writing the models to disk.')
   .describe('s', 'Database schema from which to retrieve tables')
   .describe('z', 'Output models as typescript with a definitions file')
+  .describe('f', 'Use camel case for file name')
   .argv;
 
 var dir = !argv.n && (argv.o || path.resolve(process.cwd() + '/models'));
@@ -72,6 +74,7 @@ configFile.skipTables = configFile.skipTables || (argv.T && argv.T.split(',')) |
 configFile.camelCase = !!argv.C;
 configFile.schema = argv.s || configFile.schema;
 configFile.typescript = argv.z || configFile.typescript || false;
+configFile.camelCaseForFileName = argv.f || configFile.camelCaseForFileName || false;
 
 function getDefaultPort(dialect) {
     switch (dialect.toLowerCase()) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,6 @@ AutoSequelize.prototype.run = function(callback) {
   var text = {};
   var tables = [];
   var typescriptFiles = [self.options.typescript ? tsHelper.def.getDefinitionFileStart() : '', ''];
-  var tsTableNames = [];
 
   this.build(generateText);
 
@@ -161,12 +160,11 @@ AutoSequelize.prototype.run = function(callback) {
         text[table] += "module.exports = function(sequelize, DataTypes) {\n";
         text[table] += spaces + "return sequelize.define('" + tableName + "', {\n";
       } else {
-        tsTableNames.push(tableName);
         text[table] = tsHelper.model.getModelFileStart(self.options.indentation, spaces, tableName);
       }
 
       _.each(fields, function(field, i){
-          var additional = self.options.additional
+          var additional = self.options.additional;
           if( additional && additional.timestamps !== undefined && additional.timestamps){
             if((additional.createdAt && field === 'createdAt' || additional.createdAt === field )
               ||(additional.updatedAt && field === 'updatedAt' || additional.updatedAt === field )
@@ -380,7 +378,7 @@ AutoSequelize.prototype.run = function(callback) {
         _.each(self.options.additional, addAdditionalOption)
       }
 
-      text[table] = text[table].trim()
+      text[table] = text[table].trim();
       text[table] = text[table].substring(0, text[table].length - 1);
       text[table] += "\n" + spaces + "}";
 
@@ -408,7 +406,7 @@ AutoSequelize.prototype.run = function(callback) {
       self.sequelize.close();
 
       // typescript generate tables
-      if(self.options.typescript) typescriptFiles[1] = tsHelper.model.generateTableModels(tsTableNames, self.options.spaces, self.options.indentation);
+      if(self.options.typescript) typescriptFiles[1] = tsHelper.model.generateTableModels(_.keys(text), self.options.spaces, self.options.indentation, self.options.camelCase, self.options.camelCaseForFileName);
 
       if (self.options.directory) {
         return self.write(text, typescriptFiles, callback);
@@ -416,7 +414,7 @@ AutoSequelize.prototype.run = function(callback) {
       return callback(false, text);
     });
   }
-}
+};
 
 AutoSequelize.prototype.write = function(attributes, typescriptFiles, callback) {
   var tables = _.keys(attributes);
@@ -431,8 +429,8 @@ AutoSequelize.prototype.write = function(attributes, typescriptFiles, callback) 
     callback();
   });
 
-  if(self.options.typescript){
-    if(typescriptFiles != null && typescriptFiles.length > 1){
+  if (self.options.typescript) {
+    if (typescriptFiles !== null && typescriptFiles.length > 1) {
       fs.writeFileSync(path.join(self.options.directory, 'db.d.ts'), typescriptFiles[0], 'utf8');
       fs.writeFileSync(path.join(self.options.directory, 'db.tables.ts'), typescriptFiles[1], 'utf8');
     }
@@ -442,6 +440,6 @@ AutoSequelize.prototype.write = function(attributes, typescriptFiles, callback) 
     var fileName = self.options.camelCaseForFileName ? _.camelCase(table) : table;
     fs.writeFile(path.resolve(path.join(self.options.directory, fileName + (self.options.typescript ? '.ts' : '.js'))), attributes[table], _callback);
   }
-}
+};
 
-module.exports = AutoSequelize
+module.exports = AutoSequelize;

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,8 @@ function AutoSequelize(database, username, password, options) {
     directory: './models',
     additional: {},
     freezeTableName: true,
-    typescript: false
+    typescript: false,
+    camelCaseForFileName: false
   }, options || {});
 }
 
@@ -385,7 +386,7 @@ AutoSequelize.prototype.run = function(callback) {
 
       // typescript end table in definitions file
       if(self.options.typescript) typescriptFiles[0] += tsHelper.def.getTableDefinition(tsTableDef, tableName);
-      
+
       function addAdditionalOption(value, key) {
         if (key === 'name') {
           // name: true - preserve table name always
@@ -405,7 +406,7 @@ AutoSequelize.prototype.run = function(callback) {
       _callback(null);
     }, function(){
       self.sequelize.close();
-      
+
       // typescript generate tables
       if(self.options.typescript) typescriptFiles[1] = tsHelper.model.generateTableModels(tsTableNames, self.options.spaces, self.options.indentation);
 

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -5,116 +5,116 @@ var Sequelize = require('sequelize');
 var _ = Sequelize.Utils._;
 
 function getModelFileStart(indentation, spaces, tableName) {
-    var fileStart = "/* jshint indent: " + indentation + " */\n";
-    fileStart += '// tslint:disable\n';
-    fileStart += 'import * as sequelize from \'sequelize\';\n';
-    fileStart += 'import {DataTypes} from \'sequelize\';\n';
-    fileStart += 'import {' + tableName + 'Instance, ' + tableName + 'Attribute} from \'./db\';\n\n';
-    fileStart += "module.exports = function(sequelize: sequelize.Sequelize, DataTypes: DataTypes) {\n";
-    fileStart += spaces + 'return sequelize.define<' + tableName + 'Instance, ' + tableName + 'Attribute>(\'' + tableName + '\', {\n';
-    return fileStart;
+  var fileStart = "/* jshint indent: " + indentation + " */\n";
+  fileStart += '// tslint:disable\n';
+  fileStart += 'import * as sequelize from \'sequelize\';\n';
+  fileStart += 'import {DataTypes} from \'sequelize\';\n';
+  fileStart += 'import {' + tableName + 'Instance, ' + tableName + 'Attribute} from \'./db\';\n\n';
+  fileStart += "module.exports = function(sequelize: sequelize.Sequelize, DataTypes: DataTypes) {\n";
+  fileStart += spaces + 'return sequelize.define<' + tableName + 'Instance, ' + tableName + 'Attribute>(\'' + tableName + '\', {\n';
+  return fileStart;
 }
 
 function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isCamelCaseForFile) {
-    var spaces = '';
-    for (var i = 0; i < indentation; ++ i) {
-        spaces += (isSpaces === true ? ' ' : "\t");
+  var spaces = '';
+  for (var i = 0; i < indentation; ++i) {
+    spaces += (isSpaces === true ? ' ' : "\t");
+  }
+
+  return generateImports() + generateInterface() + generateTableMapper();
+
+  function generateImports() {
+    var fileTextOutput = '// tslint:disable\n';
+    fileTextOutput += 'import * as path from \'path\';\n';
+    fileTextOutput += 'import * as sequelize from \'sequelize\';\n';
+    fileTextOutput += 'import * as def from \'./db\';\n\n';
+    return fileTextOutput;
+  }
+
+  function generateInterface() {
+    var fileTextOutput = 'export interface ITables {\n';
+    for (var i = 0; i < tableNames.length; i++) {
+      var table = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
+
+      fileTextOutput += spaces + table + ':def.' + table + 'Model;\n';
     }
+    fileTextOutput += '}\n\n';
+    return fileTextOutput;
+  }
 
-    return generateImports() + generateInterface() + generateTableMapper();
+  function generateTableMapper() {
+    var fileTextOutput = 'export const getModels = function(seq:sequelize.Sequelize):ITables {\n';
+    fileTextOutput += spaces + 'const tables:ITables = {\n';
+    for (var i = 0; i < tableNames.length; i++) {
+      var tableForClass = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
+      var tableForFile = isCamelCaseForFile ? _.camelCase(tableNames[i]) : tableNames[i];
 
-    function generateImports() {
-        var fileTextOutput = '// tslint:disable\n';
-        fileTextOutput += 'import * as path from \'path\';\n';
-        fileTextOutput += 'import * as sequelize from \'sequelize\';\n';
-        fileTextOutput += 'import * as def from \'./db\';\n\n';
-        return fileTextOutput;
+      fileTextOutput += spaces + spaces + tableForClass + ': seq.import(path.join(__dirname, \'./' + tableForFile + '\')),\n';
     }
-
-    function generateInterface() {
-        var fileTextOutput = 'export interface ITables {\n';
-        for (var i = 0; i < tableNames.length; i++) {
-            var table = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
-
-            fileTextOutput += spaces + table + ':def.' + table + 'Model;\n';
-        }
-        fileTextOutput += '}\n\n';
-        return fileTextOutput;
-    }
-
-    function generateTableMapper() {
-        var fileTextOutput = 'export const getModels = function(seq:sequelize.Sequelize):ITables {\n';
-        fileTextOutput += spaces + 'const tables:ITables = {\n';
-        for (var i = 0; i < tableNames.length; i++) {
-            var tableForClass = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
-            var tableForFile = isCamelCaseForFile ? _.camelCase(tableNames[i]) : tableNames[i];
-
-            fileTextOutput += spaces + spaces + tableForClass + ': seq.import(path.join(__dirname, \'./' + tableForFile + '\')),\n';
-        }
-        fileTextOutput += spaces + '};\n';
-        fileTextOutput += spaces + 'return tables;\n';
-        fileTextOutput += '};\n';
-        return fileTextOutput;
-    }
+    fileTextOutput += spaces + '};\n';
+    fileTextOutput += spaces + 'return tables;\n';
+    fileTextOutput += '};\n';
+    return fileTextOutput;
+  }
 }
 
 exports.model = {
-    getModelFileStart,
-    generateTableModels
+  getModelFileStart,
+  generateTableModels
 };
 
 function getDefinitionFileStart() {
-    return '// tslint:disable\nimport * as Sequelize from \'sequelize\';\n\n';
+  return '// tslint:disable\nimport * as Sequelize from \'sequelize\';\n\n';
 }
 
 function getTableDefinition(tsTableDefAttr, tableName) {
-    var tableDef = '\n// table: ' + tableName + '\n';
-    tableDef += tsTableDefAttr + '\n}\n';
-    tableDef += 'export interface ' + tableName + 'Instance extends Sequelize.Instance<' + tableName + 'Attribute>, ' + tableName + 'Attribute { }\n';
-    tableDef += 'export interface ' + tableName + 'Model extends Sequelize.Model<' + tableName + 'Instance, ' + tableName + 'Attribute> { }\n';
-    return tableDef;
+  var tableDef = '\n// table: ' + tableName + '\n';
+  tableDef += tsTableDefAttr + '\n}\n';
+  tableDef += 'export interface ' + tableName + 'Instance extends Sequelize.Instance<' + tableName + 'Attribute>, ' + tableName + 'Attribute { }\n';
+  tableDef += 'export interface ' + tableName + 'Model extends Sequelize.Model<' + tableName + 'Instance, ' + tableName + 'Attribute> { }\n';
+  return tableDef;
 }
 
 // doing this in ts helper to not clutter up main index if statement
 function getMemberDefinition(spaces, fieldName, val, allowNull) {
-    if (fieldName === undefined) return '';
-    var m = '\n' + spaces + fieldName + (allowNull === true ? '?:' : ':');
+  if (fieldName === undefined) return '';
+  var m = '\n' + spaces + fieldName + (allowNull === true ? '?:' : ':');
 
-    if (val === undefined) {
-        m += 'any';
-    } else if (val.indexOf('DataTypes.BOOLEAN') > -1) {
-        m += 'boolean';
-    } else if (val.indexOf('DataTypes.INTEGER') > -1) {
-        m += 'number';
-    } else if (val.indexOf('DataTypes.BIGINT') > -1) {
-        m += 'number';
-    } else if (val.indexOf('DataTypes.STRING') > -1) {
-        m += 'string';
-    } else if (val.indexOf('DataTypes.CHAR') > -1) {
-        m += 'string';
-    } else if (val.indexOf('DataTypes.REAL') > -1) {
-        m += 'number';
-    } else if (val.indexOf('DataTypes.TEXT') > -1) {
-        m += 'string';
-    } else if (val.indexOf('DataTypes.DATE') > -1) {
-        m += 'Date';
-    } else if (val.indexOf('DataTypes.FLOAT') > -1) {
-        m += 'number';
-    } else if (val.indexOf('DataTypes.DECIMAL') > -1) {
-        m += 'number';
-    } else if (val.indexOf('DataTypes.DOUBLE') > -1) {
-        m += 'number';
-    } else if (val.indexOf('DataTypes.UUIDV4') > -1) {
-        m += 'string';
-    } else {
-        m += 'any';
-    }
+  if (val === undefined) {
+    m += 'any';
+  } else if (val.indexOf('DataTypes.BOOLEAN') > -1) {
+    m += 'boolean';
+  } else if (val.indexOf('DataTypes.INTEGER') > -1) {
+    m += 'number';
+  } else if (val.indexOf('DataTypes.BIGINT') > -1) {
+    m += 'number';
+  } else if (val.indexOf('DataTypes.STRING') > -1) {
+    m += 'string';
+  } else if (val.indexOf('DataTypes.CHAR') > -1) {
+    m += 'string';
+  } else if (val.indexOf('DataTypes.REAL') > -1) {
+    m += 'number';
+  } else if (val.indexOf('DataTypes.TEXT') > -1) {
+    m += 'string';
+  } else if (val.indexOf('DataTypes.DATE') > -1) {
+    m += 'Date';
+  } else if (val.indexOf('DataTypes.FLOAT') > -1) {
+    m += 'number';
+  } else if (val.indexOf('DataTypes.DECIMAL') > -1) {
+    m += 'number';
+  } else if (val.indexOf('DataTypes.DOUBLE') > -1) {
+    m += 'number';
+  } else if (val.indexOf('DataTypes.UUIDV4') > -1) {
+    m += 'string';
+  } else {
+    m += 'any';
+  }
 
-    return m + ';';
+  return m + ';';
 }
 
 exports.def = {
-    getDefinitionFileStart,
-    getTableDefinition,
-    getMemberDefinition
+  getDefinitionFileStart,
+  getTableDefinition,
+  getMemberDefinition
 };

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -1,6 +1,9 @@
 // put in seperate file to keep main sequelize-auto clean
 'use strict';
 
+var Sequelize = require('sequelize');
+var _ = Sequelize.Utils._;
+
 function getModelFileStart(indentation, spaces, tableName) {
     var fileStart = "/* jshint indent: " + indentation + " */\n";
     fileStart += '// tslint:disable\n';
@@ -12,7 +15,7 @@ function getModelFileStart(indentation, spaces, tableName) {
     return fileStart;
 }
 
-function generateTableModels(tableNames, isSpaces, indentation) {
+function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isCamelCaseForFile) {
     var spaces = '';
     for (var i = 0; i < indentation; ++ i) {
         spaces += (isSpaces === true ? ' ' : "\t");
@@ -31,7 +34,9 @@ function generateTableModels(tableNames, isSpaces, indentation) {
     function generateInterface() {
         var fileTextOutput = 'export interface ITables {\n';
         for (var i = 0; i < tableNames.length; i++) {
-            fileTextOutput += spaces + tableNames[i] + ':def.' + tableNames[i] + 'Model;\n';
+            var table = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
+
+            fileTextOutput += spaces + table + ':def.' + table + 'Model;\n';
         }
         fileTextOutput += '}\n\n';
         return fileTextOutput;
@@ -41,7 +46,10 @@ function generateTableModels(tableNames, isSpaces, indentation) {
         var fileTextOutput = 'export const getModels = function(seq:sequelize.Sequelize):ITables {\n';
         fileTextOutput += spaces + 'const tables:ITables = {\n';
         for (var i = 0; i < tableNames.length; i++) {
-            fileTextOutput += spaces + spaces + tableNames[i] + ': seq.import(path.join(__dirname, \'./' + tableNames[i] + '\')),\n';
+            var tableForClass = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
+            var tableForFile = isCamelCaseForFile ? _.camelCase(tableNames[i]) : tableNames[i];
+
+            fileTextOutput += spaces + spaces + tableForClass + ': seq.import(path.join(__dirname, \'./' + tableForFile + '\')),\n';
         }
         fileTextOutput += spaces + '};\n';
         fileTextOutput += spaces + 'return tables;\n';


### PR DESCRIPTION
## 1. add missing option (camel case for file name)

In code, `createFile` function of `AutoSequelize.prototype.write` has testing `self.options.camelCaseForFileName` option, but in `bin/sequelize-auto.js` dosen't have the option.

So I add the option as `f`, `--camel-file-name`.

## 2. fix typescript case issue

When `camelCase` flag is on, the file name of import statement in `db.tables.ts` force as camel case even if `camelCaseForFileName` is off.
But actual file is saved with non camel case name.

#### example of issue
`camelCase` is on, `camelCaseForFileName` is off.
```typescript
projectLog: seq.import(path.join(__dirname, './projectLog')),
```

## 3. sync code format of `ts-help.js` with other js files