### PR TITLE
Set type to 'DATEONLY' for date columns

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -310,6 +310,9 @@ AutoSequelize.prototype.run = function(callback) {
             else if (_attr.match(/text|ntext$/)) {
               val = 'DataTypes.TEXT';
             }
+            else if (_attr==="date"){
+               val = 'DataTypes.DATEONLY';
+            }
             else if (_attr.match(/^(date|timestamp)/)) {
               val = 'DataTypes.DATE';
             }
@@ -385,7 +388,7 @@ AutoSequelize.prototype.run = function(callback) {
 
       // typescript end table in definitions file
       if(self.options.typescript) typescriptFiles[0] += tsHelper.def.getTableDefinition(tsTableDef, tableName);
-      
+
       function addAdditionalOption(value, key) {
         if (key === 'name') {
           // name: true - preserve table name always
@@ -405,7 +408,7 @@ AutoSequelize.prototype.run = function(callback) {
       _callback(null);
     }, function(){
       self.sequelize.close();
-      
+
       // typescript generate tables
       if(self.options.typescript) typescriptFiles[1] = tsHelper.model.generateTableModels(tsTableNames, self.options.spaces, self.options.indentation);
 


### PR DESCRIPTION
Fixed small bug. 'DATE' in sequelize refers  to datetimes rather than dates, so 'date' columns (at least in mysql) should be given type 'DATEONLY'.