### PR TITLE
Revert "Update eslint to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.1.5",
-    "eslint": "^4.3.0",
+    "eslint": "^3.19.0",
     "graceful-fs-extra": "^2.0.0",
     "mkdirp": "^0.5.1",
     "sequelize": "^3.30.2",


### PR DESCRIPTION
Reverts sequelize/sequelize-auto#177

This will allow applications still using version 3 of `eslint` to not break on install.