### PR TITLE
add support of "Upper Camel Case" to model name to match the popular javascript code style

### DIFF
--- a/bin/sequelize-auto
+++ b/bin/sequelize-auto
@@ -35,7 +35,7 @@ var argv = require('yargs')
   .describe('a', 'Path to a json file containing model definitions (for all tables) which are to be defined within a model\'s configuration parameter. For more info: https://sequelize.readthedocs.org/en/latest/docs/models-definition/#configuration')
   .describe('t', 'Comma-separated names of tables to import')
   .describe('T', 'Comma-separated names of tables to skip')
-  .describe('C', 'Use camel case to name models and fields')
+  .describe('C', 'Use camel case to name models and fields, if you want model name to be "Upper Camel Case" you can use like this: `-C ut`')
   .describe('n', 'Prevent writing the models to disk.')
   .describe('s', 'Database schema from which to retrieve tables')
   .describe('z', 'Output models as typescript with a definitions file')
@@ -71,7 +71,7 @@ configFile.host = argv.h || configFile.host || 'localhost';
 configFile.storage = argv.d;
 configFile.tables = configFile.tables || (argv.t && argv.t.split(',')) || null;
 configFile.skipTables = configFile.skipTables || (argv.T && argv.T.split(',')) || null;
-configFile.camelCase = !!argv.C;
+configFile.camelCase = argv.C || configFile.camelCase || false;
 configFile.schema = argv.s || configFile.schema;
 configFile.typescript = argv.z || configFile.typescript || false;
 configFile.camelCaseForFileName = argv.f || configFile.camelCaseForFileName || false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,7 @@ AutoSequelize.prototype.run = function(callback) {
             if(self.options.typescript) tsAllowNull = tsAllowNull ||self.tables[table][field][attr];
           }
           else if (attr === "defaultValue") {
-            tsAllowNull = defaultVal ? true : tsAllowNull;
+            tsAllowNull = (defaultVal !== null && defaultVal !== undefined) ? true : tsAllowNull;
 
             if (self.sequelize.options.dialect === "mssql" &&  defaultVal && defaultVal.toLowerCase() === '(newid())') {
               defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,15 +202,12 @@ AutoSequelize.prototype.run = function(callback) {
         }
 
         // typescript
-        var tsAllowNull = false;
         var tsVal = '';
 
         var isUnique = self.tables[table][field].foreignKey && self.tables[table][field].foreignKey.isUnique
 
         _.each(fieldAttr, function(attr, x){
           var isSerialKey = self.tables[table][field].foreignKey && _.isFunction(self.dialect.isSerialKey) && self.dialect.isSerialKey(self.tables[table][field].foreignKey)
-
-          tsAllowNull = tsAllowNull || isSerialKey;
 
           // We don't need the special attribute from postgresql describe table..
           if (attr === "special") {
@@ -235,11 +232,8 @@ AutoSequelize.prototype.run = function(callback) {
           }
           else if (attr === "allowNull") {
             text[table] += spaces + spaces + spaces + attr + ": " + self.tables[table][field][attr];
-            if(self.options.typescript) tsAllowNull = tsAllowNull ||self.tables[table][field][attr];
           }
           else if (attr === "defaultValue") {
-            tsAllowNull = (defaultVal !== null && defaultVal !== undefined) ? true : tsAllowNull;
-
             if (self.sequelize.options.dialect === "mssql" &&  defaultVal && defaultVal.toLowerCase() === '(newid())') {
               defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
             }
@@ -378,7 +372,7 @@ AutoSequelize.prototype.run = function(callback) {
         text[table] += "\n";
 
         // typescript, get definition for this field
-        if(self.options.typescript) tsTableDef += tsHelper.def.getMemberDefinition(spaces, fieldName, tsVal, tsAllowNull);
+        if(self.options.typescript) tsTableDef += tsHelper.def.getMemberDefinition(spaces, fieldName, tsVal);
       });
 
       text[table] += spaces + "}";

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,7 @@ AutoSequelize.prototype.run = function(callback) {
         _.each(fieldAttr, function(attr, x){
           var isSerialKey = self.tables[table][field].foreignKey && _.isFunction(self.dialect.isSerialKey) && self.dialect.isSerialKey(self.tables[table][field].foreignKey)
 
-          tsAllowNull = isSerialKey;
+          tsAllowNull = tsAllowNull || isSerialKey;
 
           // We don't need the special attribute from postgresql describe table..
           if (attr === "special") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,9 @@ AutoSequelize.prototype.run = function(callback) {
     var quoteWrapper = '"';
     if (err) console.error(err)
 
-    async.each(_.keys(self.tables), function(table, _callback){
+    var tableNames = _.sortBy(_.keys(self.tables));
+
+    async.each(tableNames, function(table, _callback){
       var fields = _.keys(self.tables[table])
         , spaces = '';
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,13 +202,15 @@ AutoSequelize.prototype.run = function(callback) {
         }
 
         // typescript
-        var tsAllowNull = '';
+        var tsAllowNull = false;
         var tsVal = '';
 
         var isUnique = self.tables[table][field].foreignKey && self.tables[table][field].foreignKey.isUnique
 
         _.each(fieldAttr, function(attr, x){
           var isSerialKey = self.tables[table][field].foreignKey && _.isFunction(self.dialect.isSerialKey) && self.dialect.isSerialKey(self.tables[table][field].foreignKey)
+
+          tsAllowNull = isSerialKey;
 
           // We don't need the special attribute from postgresql describe table..
           if (attr === "special") {
@@ -233,9 +235,11 @@ AutoSequelize.prototype.run = function(callback) {
           }
           else if (attr === "allowNull") {
             text[table] += spaces + spaces + spaces + attr + ": " + self.tables[table][field][attr];
-            if(self.options.typescript) tsAllowNull = self.tables[table][field][attr];
+            if(self.options.typescript) tsAllowNull = tsAllowNull ||self.tables[table][field][attr];
           }
           else if (attr === "defaultValue") {
+            tsAllowNull = true;
+
             if (self.sequelize.options.dialect === "mssql" &&  defaultVal && defaultVal.toLowerCase() === '(newid())') {
               defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,16 @@ AutoSequelize.prototype.run = function(callback) {
         spaces += (self.options.spaces === true ? ' ' : "\t");
       }
 
-      var tableName = self.options.camelCase ? _.camelCase(table) : table;
+      var tableName;
+      if (self.options.camelCase) {
+        tableName = _.camelCase(table);
+        if (self.options.camelCase === 'ut') {
+          tableName = _.upperFirst(tableName);
+        }
+      } else {
+        tableName = table;
+      }
+
       var tsTableDef = self.options.typescript ? 'export interface ' + tableName + 'Attribute {' : '';
 
       if(!self.options.typescript){

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,43 +238,41 @@ AutoSequelize.prototype.run = function(callback) {
               defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
             }
 
-            var val_text = defaultVal;
-
             if (isSerialKey) return true
 
             //mySql Bit fix
             if (self.tables[table][field].type.toLowerCase() === 'bit(1)') {
-              val_text = defaultVal === "b'1'" ? 1 : 0;
+              defaultVal = defaultVal === "b'1'" ? 1 : 0;
             }
             // mssql bit fix
             else if (self.sequelize.options.dialect === "mssql" && self.tables[table][field].type.toLowerCase() === "bit") {
-              val_text = defaultVal === "((1))" ? 1 : 0;
+              defaultVal = defaultVal === "((1))" ? 1 : 0;
             }
 
             if (_.isString(defaultVal)) {
               var field_type = self.tables[table][field].type.toLowerCase();
               if (_.endsWith(defaultVal, '()')) {
-                val_text = "sequelize.fn('" + defaultVal.replace(/\(\)$/, '') + "')"
+                defaultVal = "sequelize.fn('" + defaultVal.replace(/\(\)$/, '') + "')"
               }
               else if (field_type.indexOf('date') === 0 || field_type.indexOf('timestamp') === 0) {
                  if (_.includes(['current_timestamp', 'current_date', 'current_time', 'localtime', 'localtimestamp'], defaultVal.toLowerCase())) {
-                  val_text = "sequelize.literal('" + defaultVal + "')"
+                  defaultVal = "sequelize.literal('" + defaultVal + "')"
                 } else {
-                  val_text = quoteWrapper + val_text + quoteWrapper
+                  defaultVal = quoteWrapper + defaultVal + quoteWrapper
                 }
               } else {
-                val_text = quoteWrapper + val_text + quoteWrapper
+                defaultVal = quoteWrapper + defaultVal + quoteWrapper
               }
             }
 
             if(defaultVal === null || defaultVal === undefined) {
               return true;
             } else {
-              val_text = _.isString(val_text) && !val_text.match(/^sequelize\.[^(]+\(.*\)$/) ? SqlString.escape(_.trim(val_text, '"'), null, self.options.dialect) : val_text;
+              defaultVal = _.isString(defaultVal) && !defaultVal.match(/^sequelize\.[^(]+\(.*\)$/) ? SqlString.escape(_.trim(defaultVal, '"'), null, self.options.dialect) : defaultVal;
 
               // don't prepend N for MSSQL when building models...
-              val_text = _.trimStart(val_text, 'N')
-              text[table] += spaces + spaces + spaces + attr + ": " + val_text;
+              defaultVal = _.trimStart(defaultVal, 'N')
+              text[table] += spaces + spaces + spaces + attr + ": " + defaultVal;
             }
           }
           else if (attr === "type" && self.tables[table][field][attr].indexOf('ENUM') === 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,7 @@ AutoSequelize.prototype.run = function(callback) {
             if(self.options.typescript) tsAllowNull = tsAllowNull ||self.tables[table][field][attr];
           }
           else if (attr === "defaultValue") {
-            tsAllowNull = true;
+            tsAllowNull = defaultVal ? true : tsAllowNull;
 
             if (self.sequelize.options.dialect === "mssql" &&  defaultVal && defaultVal.toLowerCase() === '(newid())') {
               defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -57,8 +57,8 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
   }
 
   function generateTableMapper() {
-    var helperMethod = 'function load(path) { return seq.import(path.join(__dirname, path)); }\n\n'
-    var fileTextOutput = 'export const getModels = function(seq: sequelize.Sequelize): ITables {\n';
+    var helperMethod = 'function load(path: string) {\n  return seq.import(path.join(__dirname, path));\n }\n\n'
+    var fileTextOutput = 'export const getModels = function(seq: sequelize.Sequelize): ITables {\n\n';
     fileTextOutput += spaces + helperMethod;
     fileTextOutput += spaces + 'return {\n';
     for (var i = 0; i < tableNames.length; i++) {

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -88,42 +88,39 @@ function getTableDefinition(tsTableDefAttr, tableName) {
   return tableDef;
 }
 
-// doing this in ts helper to not clutter up main index if statement
-function getMemberDefinition(spaces, fieldName, val, allowNull) {
-  if (fieldName === undefined) return '';
-  var m = '\n' + spaces + fieldName + (allowNull === true ? '?:' : ':');
+var typeMap = {
+  BOOLEAN: 'boolean',
+  INTEGER: 'number',
+  BIGINT: 'number',
+  REAL: 'number',
+  FLOAT: 'number',
+  DECIMAL: 'number',
+  DOUBLE: 'number',
+  STRING: 'string',
+  CHAR: 'string',
+  TEXT: 'string',
+  UUIDV4: 'string',
+  DATE: 'Date'
+};
 
-  if (val === undefined) {
-    m += 'any';
-  } else if (val.indexOf('DataTypes.BOOLEAN') > -1) {
-    m += 'boolean';
-  } else if (val.indexOf('DataTypes.INTEGER') > -1) {
-    m += 'number';
-  } else if (val.indexOf('DataTypes.BIGINT') > -1) {
-    m += 'number';
-  } else if (val.indexOf('DataTypes.STRING') > -1) {
-    m += 'string';
-  } else if (val.indexOf('DataTypes.CHAR') > -1) {
-    m += 'string';
-  } else if (val.indexOf('DataTypes.REAL') > -1) {
-    m += 'number';
-  } else if (val.indexOf('DataTypes.TEXT') > -1) {
-    m += 'string';
-  } else if (val.indexOf('DataTypes.DATE') > -1) {
-    m += 'Date';
-  } else if (val.indexOf('DataTypes.FLOAT') > -1) {
-    m += 'number';
-  } else if (val.indexOf('DataTypes.DECIMAL') > -1) {
-    m += 'number';
-  } else if (val.indexOf('DataTypes.DOUBLE') > -1) {
-    m += 'number';
-  } else if (val.indexOf('DataTypes.UUIDV4') > -1) {
-    m += 'string';
-  } else {
-    m += 'any';
+function getType(val) {
+  if (!val) {
+    return 'any';
   }
+  var result = val.match(/DataTypes\.([A-Z]+)/);
+  if (!result) {
+    return 'any';
+  }
+  var dataType = typeMap[result[1]];
+  return dataType || 'any';
+}
 
-  return m + ';';
+// doing this in ts helper to not clutter up main index if statement
+function getMemberDefinition(spaces, fieldName, val) {
+  if (fieldName === undefined) {
+    return '';
+  }
+  return '\n' + spaces + fieldName + '?:' + getType(val) + ';';
 }
 
 exports.def = {

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -16,6 +16,7 @@ function getModelFileStart(indentation, spaces, tableName) {
 }
 
 function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isCamelCaseForFile) {
+  tableNames = _.sortBy(tableNames);
   var spaces = '';
   for (var i = 0; i < indentation; ++i) {
     spaces += (isSpaces === true ? ' ' : "\t");

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -57,7 +57,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
   }
 
   function generateTableMapper() {
-    var helperMethod = 'function load(filePath: string) {\n    return seq.import(path.join(__dirname, filePath));\n  }\n\n'
+    var helperMethod = 'function load(filePath: string) {\n' + spaces + spaces + 'return seq.import(path.join(__dirname, filePath));\n' + spaces + '}\n\n'
     var fileTextOutput = 'export const getModels = function(seq: sequelize.Sequelize): ITables {\n\n';
     fileTextOutput += spaces + helperMethod;
     fileTextOutput += spaces + 'return {\n';
@@ -65,7 +65,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
       var tableForClass = transferTableName(tableNames[i]);
       var tableForFile = isCamelCaseForFile ? _.camelCase(tableNames[i]) : tableNames[i];
 
-      fileTextOutput += spaces + spaces + tableForClass + ': load(\'./' + tableForFile + '\'),\n';
+      fileTextOutput += spaces + spaces + tableForClass + ': load(\'' + tableForFile + '\'),\n';
     }
     fileTextOutput += spaces + '} as ITables;\n};';
     return fileTextOutput;

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -50,7 +50,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
     for (var i = 0; i < tableNames.length; i++) {
       var table = transferTableName(tableNames[i])
 
-      fileTextOutput += spaces + table + ':def.' + table + 'Model;\n';
+      fileTextOutput += spaces + table + ': def.' + table + 'Model;\n';
     }
     fileTextOutput += '}\n\n';
     return fileTextOutput;

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -23,6 +23,19 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
 
   return generateImports() + generateInterface() + generateTableMapper();
 
+  function transferTableName(tableName) {
+    var result;
+    if (isCamelCase) {
+      result = _.camelCase(tableName);
+      if (isCamelCase === 'ut') {
+        result = _.upperFirst(result);
+      }
+    } else {
+      result = tableName;
+    }
+    return result;
+  }
+
   function generateImports() {
     var fileTextOutput = '// tslint:disable\n';
     fileTextOutput += 'import * as path from \'path\';\n';
@@ -34,7 +47,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
   function generateInterface() {
     var fileTextOutput = 'export interface ITables {\n';
     for (var i = 0; i < tableNames.length; i++) {
-      var table = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
+      var table = transferTableName(tableNames[i])
 
       fileTextOutput += spaces + table + ':def.' + table + 'Model;\n';
     }
@@ -46,7 +59,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
     var fileTextOutput = 'export const getModels = function(seq:sequelize.Sequelize):ITables {\n';
     fileTextOutput += spaces + 'const tables:ITables = {\n';
     for (var i = 0; i < tableNames.length; i++) {
-      var tableForClass = isCamelCase ? _.camelCase(tableNames[i]) : tableNames[i];
+      var tableForClass = transferTableName(tableNames[i]);
       var tableForFile = isCamelCaseForFile ? _.camelCase(tableNames[i]) : tableNames[i];
 
       fileTextOutput += spaces + spaces + tableForClass + ': seq.import(path.join(__dirname, \'./' + tableForFile + '\')),\n';

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -57,7 +57,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
   }
 
   function generateTableMapper() {
-    var helperMethod = 'function load(path: string) {\n  return seq.import(path.join(__dirname, path));\n }\n\n'
+    var helperMethod = 'function load(filePath: string) {\n    return seq.import(path.join(__dirname, filePath));\n  }\n\n'
     var fileTextOutput = 'export const getModels = function(seq: sequelize.Sequelize): ITables {\n\n';
     fileTextOutput += spaces + helperMethod;
     fileTextOutput += spaces + 'return {\n';
@@ -67,7 +67,7 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
 
       fileTextOutput += spaces + spaces + tableForClass + ': load(\'./' + tableForFile + '\'),\n';
     }
-    fileTextOutput += spaces + '};\n';
+    fileTextOutput += spaces + '} as ITables;\n};';
     return fileTextOutput;
   }
 }

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -57,17 +57,17 @@ function generateTableModels(tableNames, isSpaces, indentation, isCamelCase, isC
   }
 
   function generateTableMapper() {
-    var fileTextOutput = 'export const getModels = function(seq:sequelize.Sequelize):ITables {\n';
-    fileTextOutput += spaces + 'const tables:ITables = {\n';
+    var helperMethod = 'function load(path) { return seq.import(path.join(__dirname, path)); }\n\n'
+    var fileTextOutput = 'export const getModels = function(seq: sequelize.Sequelize): ITables {\n';
+    fileTextOutput += spaces + helperMethod;
+    fileTextOutput += spaces + 'return {\n';
     for (var i = 0; i < tableNames.length; i++) {
       var tableForClass = transferTableName(tableNames[i]);
       var tableForFile = isCamelCaseForFile ? _.camelCase(tableNames[i]) : tableNames[i];
 
-      fileTextOutput += spaces + spaces + tableForClass + ': seq.import(path.join(__dirname, \'./' + tableForFile + '\')),\n';
+      fileTextOutput += spaces + spaces + tableForClass + ': load(\'./' + tableForFile + '\'),\n';
     }
     fileTextOutput += spaces + '};\n';
-    fileTextOutput += spaces + 'return tables;\n';
-    fileTextOutput += '};\n';
     return fileTextOutput;
   }
 }


### PR DESCRIPTION
change `-C` option, 
if you use `-C` only, generate code is the same like before(typescript):
```
export interface tableNameAttribute {
  id:number;
  name?:string;
}
```
if you use `-C ut` (means "Upper Camel Case" table name),generate code is the same like this(typescript):
```
export interface TableNameAttribute {
  id:number;
  name?:string;
}
```