### PR TITLE
fix: generated attributes with spaces should be wrapped in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,50 +61,50 @@ Produces a file/files such as ./models/Users.js which looks like:
 
     module.exports = function(sequelize, DataTypes) {
       return sequelize.define('Users', {
-        id: {
+        'id': {
           type: DataTypes.INTEGER(11),
           allowNull: false,
           primaryKey: true,
           autoIncrement: true
         },
-        username: {
+        'username': {
           type: DataTypes.STRING,
           allowNull: true
         },
-        touchedAt: {
+        'touchedAt': {
           type: DataTypes.DATE,
           allowNull: true
         },
-        aNumber: {
+        'aNumber': {
           type: DataTypes.INTEGER(11),
           allowNull: true
         },
-        bNumber: {
+        'bNumber': {
           type: DataTypes.INTEGER(11),
           allowNull: true
         },
-        validateTest: {
+        'validateTest': {
           type: DataTypes.INTEGER(11),
           allowNull: true
         },
-        validateCustom: {
+        'validateCustom': {
           type: DataTypes.STRING,
           allowNull: false
         },
-        dateAllowNullTrue: {
+        'dateAllowNullTrue': {
           type: DataTypes.DATE,
           allowNull: true
         },
-        defaultValueBoolean: {
+        'defaultValueBoolean': {
           type: DataTypes.BOOLEAN,
           allowNull: true,
           defaultValue: '1'
         },
-        createdAt: {
+        'createdAt': {
           type: DataTypes.DATE,
           allowNull: false
         },
-        updatedAt: {
+        'updatedAt': {
           type: DataTypes.DATE,
           allowNull: false
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -182,7 +182,7 @@ AutoSequelize.prototype.run = function(callback) {
         // column's attributes
         var fieldAttr = _.keys(self.tables[table][field]);
         var fieldName = self.options.camelCase ? _.camelCase(field) : field;
-        text[table] += spaces + spaces + fieldName + ": {\n";
+        text[table] += spaces + spaces + "'" + fieldName + "': {\n";
 
         // Serial key for postgres...
         var defaultVal = self.tables[table][field].defaultValue;

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -47,9 +47,9 @@ describe(helpers.getTestDialectTeaser("sequelize-auto"), function() {
         })
 
         self.HistoryLog = self.sequelize.define('HistoryLog', {
-          someText:  { type: helpers.Sequelize.STRING },
-          aNumber:   { type: helpers.Sequelize.INTEGER },
-          aRandomId: { type: helpers.Sequelize.INTEGER }
+          'some Text':  { type: helpers.Sequelize.STRING },
+          'aNumber':   { type: helpers.Sequelize.INTEGER },
+          'aRandomId': { type: helpers.Sequelize.INTEGER }
         })
 
         self.ParanoidUser = self.sequelize.define('ParanoidUser', {
@@ -121,7 +121,7 @@ describe(helpers.getTestDialectTeaser("sequelize-auto"), function() {
       var Users = this.sequelize.import(path.join(testConfig.directory, 'Users'));
 
       expect(HistoryLogs.tableName).to.equal('HistoryLogs');
-      ['someText', 'aNumber', 'aRandomId', 'id'].forEach(function(field){
+      ['some Text', 'aNumber', 'aRandomId', 'id'].forEach(function(field){
         expect(HistoryLogs.rawAttributes[field]).to.exist;
       });
 
@@ -135,7 +135,7 @@ describe(helpers.getTestDialectTeaser("sequelize-auto"), function() {
         expect(Users.rawAttributes[field]).to.exist;
       });
 
-      expect(HistoryLogs.rawAttributes.someText.type.toString().indexOf('VARCHAR')).to.be.at.above(-1);
+      expect(HistoryLogs.rawAttributes['some Text'].type.toString().indexOf('VARCHAR')).to.be.at.above(-1);
       expect(Users.rawAttributes.validateCustom.allowNull).to.be.false;
       expect(Users.rawAttributes.dateAllowNullTrue.allowNull).to.be.true;
       expect(Users.rawAttributes.dateAllowNullTrue.type).to.match(/time/i);


### PR DESCRIPTION
fix #182 

I wrap all column names with single quotes and add test for it.
And I also modify README.md to display correct output.

#### Example:
Original output
```
module.exports = function(sequelize, DataTypes) {
  return sequelize.define('HistoryLogs', {
    id: {
      type: DataTypes.INTEGER(11),
      allowNull: false,
      primaryKey: true,
      autoIncrement: true
    },
    some Text: {
      type: DataTypes.STRING(255),
      allowNull: true
    },...
  }, {
    tableName: 'HistoryLogs'
  });
};
```
change to
```
module.exports = function(sequelize, DataTypes) {
  return sequelize.define('HistoryLogs', {
    'id': {
      type: DataTypes.INTEGER(11),
      allowNull: false,
      primaryKey: true,
      autoIncrement: true
    },
    'some Text': {
      type: DataTypes.STRING(255),
      allowNull: true
    },...
  }, {
    tableName: 'HistoryLogs'
  });
};
```