### PR TITLE
fix another schema with same table name and column name

### DIFF
--- a/lib/dialects/index.js
+++ b/lib/dialects/index.js
@@ -47,6 +47,7 @@ exports.mysql = {
       FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS K \
       LEFT JOIN INFORMATION_SCHEMA.COLUMNS AS C \
         ON C.TABLE_NAME = K.TABLE_NAME AND C.COLUMN_NAME = K.COLUMN_NAME \
+        AND C.TABLE_SCHEMA = K.CONSTRAINT_SCHEMA \
       WHERE \
         K.TABLE_NAME = '" + tableName + "' \
         AND K.CONSTRAINT_SCHEMA = '" + schemaName + "';";


### PR DESCRIPTION
when an other schema with the same table and column name as target schema and table, the result key is not correct. this fix this bug