### PR TITLE
Removing ts required flag from autogenerated ids; adding nullable types.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,6 +194,7 @@ AutoSequelize.prototype.run = function(callback) {
 
         // typescript
         var tsAllowNull = '';
+        var tsAutoIncrement = '';
         var tsVal = '';
 
         var isUnique = self.tables[table][field].foreignKey && self.tables[table][field].foreignKey.isUnique
@@ -209,6 +210,7 @@ AutoSequelize.prototype.run = function(callback) {
           if (attr === "foreignKey") {
             if (isSerialKey) {
               text[table] += spaces + spaces + spaces + "autoIncrement: true";
+              tsAutoIncrement = true;
             }
             else if (foreignKey.isForeignKey) {
               text[table] += spaces + spaces + spaces + "references: {\n";
@@ -365,7 +367,7 @@ AutoSequelize.prototype.run = function(callback) {
         text[table] += "\n";
 
         // typescript, get definition for this field
-        if(self.options.typescript) tsTableDef += tsHelper.def.getMemberDefinition(spaces, fieldName, tsVal, tsAllowNull);
+        if(self.options.typescript) tsTableDef += tsHelper.def.getMemberDefinition(spaces, fieldName, tsVal, tsAllowNull, tsAutoIncrement);
       });
 
       text[table] += spaces + "}";

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -76,9 +76,10 @@ function getTableDefinition(tsTableDefAttr, tableName) {
 }
 
 // doing this in ts helper to not clutter up main index if statement
-function getMemberDefinition(spaces, fieldName, val, allowNull) {
+function getMemberDefinition(spaces, fieldName, val, allowNull, autoIncrement) {
   if (fieldName === undefined) return '';
-  var m = '\n' + spaces + fieldName + (allowNull === true ? '?:' : ':');
+  var isRequiredField = allowNull === true && autoIncrement === true;
+  var m = '\n' + spaces + fieldName + (isRequiredField ? '?:' : ':');
 
   if (val === undefined) {
     m += 'any';

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -111,6 +111,10 @@ function getMemberDefinition(spaces, fieldName, val, allowNull, autoIncrement) {
     m += 'any';
   }
 
+  if (m.indexOf('any') === -1 && allowNull) {
+    m += "|null";
+  }
+
   return m + ';';
 }
 


### PR DESCRIPTION
This is just an enhancement to the way Typescript definitions are generated.  I've added the `?` optional flag for any id that is `AUTO_INCREMENT`ed and applied `|null` to any column which is nullable.

See the example below:

```sql
CREATE TABLE `example` (
  `id` INT(11) NOT NULL PRIMARY KEY AUTO_INCREMENT,
  `foo` INT(11) NOT NULL,
  `bar` TEXT
)
```

```typescript
export interface exampleAttribute {
  id?:number;
  foo:number;
  bar?:number|null;
}
```
