### PR TITLE
Add logic to set timestamps to false on a model if timestamp columns do not exist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+x-postgres:
+  &postgres
+  POSTGRES_DB: sequelize_auto_test
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD:
+  POSTGRES_HOST: postgres
+  POSTGRES_SSL: 'false'
+  POSTGRES_PORT: 5432
+  POSTGRES_SCHEMA: public # currently must be "public"
+
+services:
+  postgres:
+    image: postgres:10.5-alpine
+    restart: always
+    environment:
+      <<: *postgres
+    ports:
+      - 5432:5432
+    command: postgres -c 'max_connections=250'

--- a/lib/index.js
+++ b/lib/index.js
@@ -154,6 +154,8 @@ AutoSequelize.prototype.run = function(callback) {
 
       var tableName = self.options.camelCase ? _.camelCase(table) : table;
       var tsTableDef = self.options.typescript ? 'export interface ' + tableName + 'Attribute {' : '';
+      var createdAt = false
+      var updatedAt = false
 
       if(!self.options.typescript){
         text[table] = "/* jshint indent: " + self.options.indentation + " */\n\n";
@@ -164,6 +166,14 @@ AutoSequelize.prototype.run = function(callback) {
       }
 
       _.each(fields, function(field, i){
+          if (field === 'createdAt') {
+            createdAt = true
+          }
+
+          if (field === 'updatedAt') {
+            updatedAt = true
+          }
+
           var additional = self.options.additional;
           if( additional && additional.timestamps !== undefined && additional.timestamps){
             if((additional.createdAt && field === 'createdAt' || additional.createdAt === field )
@@ -379,6 +389,11 @@ AutoSequelize.prototype.run = function(callback) {
 
       if (hasadditional) {
         _.each(self.options.additional, addAdditionalOption)
+      }
+
+      // if additional does not exist or timestamps is not set and timestamp columns do not exist
+      if ((!hasadditional || self.options.additional.timestamps === undefined) &&  !createdAt && !updatedAt) {
+        text[table] += spaces + spaces  + "timestamps: false,\n";
       }
 
       text[table] = text[table].trim();


### PR DESCRIPTION
I created this PR because this is the only thing blocking me from sequelize-auto working for our team in a purely dynamic way. I wanted to get the conversation going to see if this is functionality you would accept and if so, will add more effort to bring this up to standards for getting this merged.

So this adds `timestamps: false` to models where the source table does not have `createdAt` and `updatedAt` columns.