### PR TITLE
update README : mysql -> mysql2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will need to install the correct dialect binding globally before using seque
 
 Example for MySQL/MariaDB
 
-`npm install -g mysql`
+`npm install -g mysql2`
 
 Example for Postgres
 


### PR DESCRIPTION
This has 2 benefits.
1. mysql2 is generally more preferable.
2. This syncs with the README#Installation of [sequelize/sequelize](https://github.com/sequelize/sequelize#installation)