### PR TITLE
fix Datatypes TypeError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,9 +215,9 @@ AutoSequelize.prototype.run = function(callback) {
           str += spaces + "static init(sequelize, DataTypes) {\n";
           str += spaces + "super.init({\n";
         } else if (self.options.esm) {
-          str += "import { Model } from 'sequelize';\n\n"
+          str += "import { Model, DataTypes } from 'sequelize';\n\n"
           str += "export default class " + tableName + " extends Model {\n";
-          str += spaces + "static init(sequelize, DataTypes) {\n";
+          str += spaces + "static init(sequelize) {\n";
           str += spaces + "super.init({\n";
         } else {
           str += "module.exports = function(sequelize, DataTypes) {\n";


### PR DESCRIPTION
Changing this way of getting Datatypes, prevents this type of error in the terminal.

`
          type: DataTypes.INTEGER.UNSIGNED,
                          ^
TypeError: Cannot read property 'INTEGER' of undefined
`