### PR TITLE
Fix(MySQL) : Missing autoIncrement attribute in generated models #419

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,8 @@ AutoSequelize.prototype.build = function(callback) {
     }
 
     const tableQname = makeTableQName(table)
-    const sql = self.dialect.getForeignKeysQuery(table.table_name, table.table_schema);
+    const sql = self.dialect.getForeignKeysQuery(table.table_name, table.table_schema || self.sequelize.config.database);
+
     self.sequelize.query(sql, {
       type: self.sequelize.QueryTypes.SELECT,
       raw: true


### PR DESCRIPTION
Issue:
autoIncrement: true is missing on generated models. #419

Environment:
OS: Linux
MySQL: 8.0.11
node: v12.13.0
npm: v6.13.7
sequelize-auto: 0.5.3

Details:
During the generation, I realized that the autoIncrement was being removed so I started to notice that when you have several schemas with tables and columns of the same name but with different properties (the first one having autoIncrement and the second one not) the library goes through the schemas and makes the thus replacing the autoIncrement.