### PR TITLE
Try to be more specific about what to cast as.

### DIFF
--- a/src/auto-writer.ts
+++ b/src/auto-writer.ts
@@ -74,8 +74,8 @@ export class AutoWriter {
   private createAssociations(typeScript: boolean) {
     let strBelongs = "";
     let strBelongsToMany = "";
-    // declare through model "as any" because typings don't match
-    const asAny = typeScript ? " as any" : "";
+    // declare through model "as Model" because typings don't match
+    const asAny = typeScript ? " as typeof Model" : "";
     const fkTables = _.keys(this.foreignKeys).sort();
     fkTables.forEach(t => {
       const [schemaName, tableName] = qNameSplit(t);


### PR DESCRIPTION
The `through` option accepts `typeof Model | string | ThroughOptions`, and we are passing a `typeof <something extends Model>`, and for some reason, tsc cannot infer that the model we are passing is actually a `typeof Model`, probably because it would have to deconstruct too much to figure out it is ok.

There is something fishy because tsc also agrees with the type if I write `through: typeof TheModel` which is clearly wrong.

Note that the `as any` works, I just don't like having `any` in my code when I can avoid it.