### PR TITLE
`DATE` and `TIME`  are actually strings in sequelize not `Date`s

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -661,7 +661,7 @@ export class AutoGenerator {
   }
 
   private isNumber(fieldType: string): boolean {
-    return /^(smallint|mediumint|tinyint|int|bigint|float|money|smallmoney|double|decimal|numeric|real|date|time)(?:\(|$)/.test(fieldType);
+    return /^(smallint|mediumint|tinyint|int|bigint|float|money|smallmoney|double|decimal|numeric|real)/.test(fieldType);
   }
 
   private isBoolean(fieldType: string): boolean {
@@ -673,7 +673,7 @@ export class AutoGenerator {
   }
 
   private isString(fieldType: string): boolean {
-    return /^(char|nchar|string|varying|varchar|nvarchar|text|longtext|mediumtext|tinytext|ntext|uuid|uniqueidentifier)/.test(fieldType);
+    return /^(char|nchar|string|varying|varchar|nvarchar|text|longtext|mediumtext|tinytext|ntext|uuid|uniqueidentifier|date|time)(?:\(|$)/.test(fieldType);
   }
 
   private isArray(fieldType: string): boolean {

--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -599,7 +599,8 @@ export class AutoGenerator {
   }
 
   private getTypeScriptFieldType(fieldObj: any, attr: string) {
-    const fieldType = (fieldObj[attr] || '').toLowerCase();
+    const rawFieldType = fieldObj[attr] || ''
+    const fieldType = rawFieldType.toLowerCase();
     let jsType: string;
     if (this.isString(fieldType)) {
       jsType = 'string';
@@ -613,7 +614,7 @@ export class AutoGenerator {
       const eltype = this.getTypeScriptFieldType(fieldObj, "special");
       jsType = eltype + '[]';
     } else if (this.isEnum(fieldType)) {
-      const values = fieldType.substring(5, fieldType.length - 1).split(',').join(' | ');
+      const values = rawFieldType.substring(5, rawFieldType.length - 1).split(',').join(' | ');
       jsType = values;
     } else {
       console.log(`Missing TypeScript type: ${fieldType}`);
@@ -660,7 +661,7 @@ export class AutoGenerator {
   }
 
   private isNumber(fieldType: string): boolean {
-    return /^(smallint|mediumint|tinyint|int|bigint|float|money|smallmoney|double|decimal|numeric|real)/.test(fieldType);
+    return /^(smallint|mediumint|tinyint|int|bigint|float|money|smallmoney|double|decimal|numeric|real|date|time)(?:\(|$)/.test(fieldType);
   }
 
   private isBoolean(fieldType: string): boolean {
@@ -668,7 +669,7 @@ export class AutoGenerator {
   }
 
   private isDate(fieldType: string): boolean {
-    return /^(date|time|timestamp)/.test(fieldType);
+    return /^(datetime|timestamp)/.test(fieldType);
   }
 
   private isString(fieldType: string): boolean {


### PR DESCRIPTION
`Sequelize.DataTypes.DATEONLY` and `Sequelize.DataTypes.TIME` are always strings, both from setters and getters. Only `Sequlize.DataTypes.DATE` and `Sequelize.DataTypes.TIMESTAMP` get converted to `Date()`s when using `.get()` or setters