### PR TITLE
Escape default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-auto",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "publishConfig": {
     "tag": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "lodash": "^4.17.20",
     "mkdirp": "^1.0.4",
-    "yargs": "^15.4.1",
-    "lodash": "^4.17.20"
+    "yargs": "^15.4.1"
   },
   "peerDependencies": {
     "sequelize": ">3.30.0"

--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -221,7 +221,7 @@ export class AutoGenerator {
     const fieldName = recase(this.options.caseProp, field);
     let str = this.quoteName(fieldName) + ": {\n";
 
-    let defaultVal = fieldObj.defaultValue;
+    let defaultVal = this.escapeSpecial(fieldObj.defaultValue);
     const quoteWrapper = '"';
 
     const unique = fieldObj.unique || fieldObj.foreignKey && fieldObj.foreignKey.isUnique;


### PR DESCRIPTION
Fix for #476, postgresql bytea column type writing out `\x` for the default value.