### PR TITLE
WIP: Dockerize databases to speed-up local testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,40 @@
-# Create database containers to simplify running tests
+# Create database containers to simplify running tests.
+
+# NB: Init scripts are executed in alphabetic order, hence the renaming of files
+# within the container to ensure "model" migrations (i.e. those creating tables)
+# are executed before those to seed records. After making changes to any init
+# scripts you'll have to `docker-compose down` and `docker-compose up` to see
+# this reflected within the containers.
+
+# Database containers don't have persistent volumes. This means any changes you
+# make (eg. inserting records) will be lost after a `docker-compose down` and
+# `docker-compose up`.
 
 version: "3.5"
 
 services:
+  mysql:
+    environment:
+      MYSQL_DATABASE: northwind
+      MYSQL_USER: sequelizeauto
+      MYSQL_PASSWORD: sequelizeauto
+      MYSQL_ROOT_PASSWORD: sequelizeauto
+    image: mysql:8.0
+    ports:
+      - 3306:3306
+    restart: always
+    volumes:
+      - ./sample/dbscripts/mysql-sample-model.sql:/docker-entrypoint-initdb.d/001.mysql-sample-model.sql
+      - ./sample/dbscripts/mysql-sample-data.sql:/docker-entrypoint-initdb.d/002.mysql-sample-data.sql
   postgres:
     environment:
       POSTGRES_USER: sequelizeauto
       POSTGRES_PASSWORD: sequelizeauto
-      POSTGRES_DB: sequelizeauto
+      POSTGRES_DB: northwind
     image: postgres:12
     ports:
       - 5432:5432
     restart: always
     volumes:
-      # NB: Postgres will run init scripts in alphabetic order, hence we need
-      # to ensure `model` (the migration responsible for creating tables) is
-      # executed first.
-      # After making changes to either of these files, you'll have to
-      # `docker-compose down` and `docker-compose up` for these migrations to
-      # be re-executed.
       - ./sample/dbscripts/postgres-sample-model.sql:/docker-entrypoint-initdb.d/001.postgres-sample-model.sql
       - ./sample/dbscripts/postgres-sample-data.sql:/docker-entrypoint-initdb.d/002.postgres-sample-data.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,25 @@
 version: "3.5"
 
 services:
+  mssql:
+    build:
+      context: ./
+      dockerfile: mssql.Dockerfile
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Developer"
+      SA_PASSWORD: "Sequelizeauto!"
+    ports:
+      - 1433:1433
+    volumes:
+      - ./sample/dbscripts/mssql-sample-model.sql:/usr/db/mssql-sample-model.sql
+      - ./sample/dbscripts/mssql-sample-data.sql:/usr/db/mssql-sample-data.sql
   mysql:
     environment:
-      MYSQL_DATABASE: northwind
-      MYSQL_USER: sequelizeauto
-      MYSQL_PASSWORD: sequelizeauto
-      MYSQL_ROOT_PASSWORD: sequelizeauto
+      MYSQL_DATABASE: "northwind"
+      MYSQL_USER: "sequelizeauto"
+      MYSQL_PASSWORD: "Sequelizeauto!"
+      MYSQL_ROOT_PASSWORD: "Sequelizeauto!"
     image: mysql:8.0
     ports:
       - 3306:3306
@@ -28,9 +41,9 @@ services:
       - ./sample/dbscripts/mysql-sample-data.sql:/docker-entrypoint-initdb.d/002.mysql-sample-data.sql
   postgres:
     environment:
-      POSTGRES_USER: sequelizeauto
-      POSTGRES_PASSWORD: sequelizeauto
-      POSTGRES_DB: northwind
+      POSTGRES_USER: "sequelizeauto"
+      POSTGRES_PASSWORD: "Sequelizeauto!"
+      POSTGRES_DB: "northwind"
     image: postgres:12
     ports:
       - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,16 @@ services:
     volumes:
       - ./sample/dbscripts/postgres-sample-model.sql:/docker-entrypoint-initdb.d/001.postgres-sample-model.sql
       - ./sample/dbscripts/postgres-sample-data.sql:/docker-entrypoint-initdb.d/002.postgres-sample-data.sql
+  # Unlike the other databases, sqlite doesn't require leaving a process
+  # running. This container is just responsible for writing out a sqlite3
+  # database file in `sample/northwind.sqlite`. It's normal for this to
+  # exit immediately after generating this file. (As with other databases
+  # this is wiped and recreated from scratch on `docker-compose up`)
+  sqlite:
+    build:
+      context: ./
+      dockerfile: sqlite3.Dockerfile
+    volumes:
+      - ./sample/dbscripts/sqlite-sample-model.sql:/usr/db/sqlite-sample-model.sql
+      - ./sample/dbscripts/sqlite-sample-data.sql:/usr/db/sqlite-sample-data.sql
+      - ./sample/northwind.sqlite:/usr/db/northwind.sqlite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# Create database containers to simplify running tests
+
+version: "3.5"
+
+services:
+  postgres:
+    environment:
+      POSTGRES_USER: sequelizeauto
+      POSTGRES_PASSWORD: sequelizeauto
+      POSTGRES_DB: sequelizeauto
+    image: postgres:12
+    ports:
+      - 5432:5432
+    restart: always
+    volumes:
+      # NB: Postgres will run init scripts in alphabetic order, hence we need
+      # to ensure `model` (the migration responsible for creating tables) is
+      # executed first.
+      # After making changes to either of these files, you'll have to
+      # `docker-compose down` and `docker-compose up` for these migrations to
+      # be re-executed.
+      - ./sample/dbscripts/postgres-sample-model.sql:/docker-entrypoint-initdb.d/001.postgres-sample-model.sql
+      - ./sample/dbscripts/postgres-sample-data.sql:/docker-entrypoint-initdb.d/002.postgres-sample-data.sql

--- a/mssql.Dockerfile
+++ b/mssql.Dockerfile
@@ -1,0 +1,15 @@
+# mssql doesn't have an in-built way of initializing a database on
+# container startup, hence we'll have to do some setup ourselves.
+# Derived from: https://github.com/microsoft/mssql-docker/tree/master/linux/preview/examples/mssql-customize
+
+FROM mcr.microsoft.com/mssql/server:2019-CU9-ubuntu-16.04
+
+# Create a config directory
+RUN mkdir -p /usr/config
+WORKDIR /usr/config
+
+# Bundle config source
+COPY ./sample/dbscripts/mssql-docker-entrypoint.sh /usr/config/entrypoint.sh
+COPY ./sample/dbscripts/mssql-docker-setup.sh /usr/config/setup.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,0 +1,1 @@
+northwind.sqlite

--- a/sample/dbscripts/mssql-docker-entrypoint.sh
+++ b/sample/dbscripts/mssql-docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start the script to run initial migrations
+/usr/config/setup.sh &
+
+# Start SQL Server
+/opt/mssql/bin/sqlservr

--- a/sample/dbscripts/mssql-docker-setup.sh
+++ b/sample/dbscripts/mssql-docker-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Wait 60 seconds for SQL Server to start up by ensuring that
+# calling SQLCMD does not return an error code, which will ensure that sqlcmd is accessible
+# and that system and user databases return "0" which means all databases are in an "online" state
+# https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2017
+
+DBSTATUS=1
+ERRCODE=1
+i=0
+
+while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
+	i=$i+1
+	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
+	ERRCODE=$?
+	sleep 1
+done
+
+if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then
+	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
+	exit 1
+fi
+
+# Run the setup script to create the DB and the schema in the DB
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i /usr/db/mssql-sample-model.sql
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i /usr/db/mssql-sample-data.sql

--- a/sample/dbscripts/mysql-sample-model.sql
+++ b/sample/dbscripts/mysql-sample-model.sql
@@ -1,3 +1,5 @@
+CREATE DATABASE IF NOT EXISTS "sequelize_auto_test";
+
 CREATE DATABASE  IF NOT EXISTS `northwind` /*!40100 DEFAULT CHARACTER SET utf8 */;
 USE `northwind`;
 

--- a/sample/dbscripts/mysql-sample-model.sql
+++ b/sample/dbscripts/mysql-sample-model.sql
@@ -1,5 +1,5 @@
-CREATE DATABASE  IF NOT EXISTS `Northwind` /*!40100 DEFAULT CHARACTER SET utf8 */;
-USE `Northwind`;
+CREATE DATABASE  IF NOT EXISTS `northwind` /*!40100 DEFAULT CHARACTER SET utf8 */;
+USE `northwind`;
 
 DROP TABLE IF EXISTS `order_item`;
 DROP TABLE IF EXISTS `orderitem`;

--- a/sample/dbscripts/postgres-sample-model.sql
+++ b/sample/dbscripts/postgres-sample-model.sql
@@ -1,6 +1,6 @@
---DROP DATABASE IF EXISTS "Northwind";
---CREATE DATABASE "Northwind";
--- Need to do the above separately, then reconnect to Northwind database
+--DROP DATABASE IF EXISTS "northwind";
+--CREATE DATABASE "northwind";
+-- Need to do the above separately, then reconnect to northwind database
 
 DROP TABLE IF EXISTS "OrderItem";
 DROP TABLE IF EXISTS "Product";

--- a/sample/dbscripts/postgres-sample-model.sql
+++ b/sample/dbscripts/postgres-sample-model.sql
@@ -2,6 +2,9 @@
 --CREATE DATABASE "northwind";
 -- Need to do the above separately, then reconnect to northwind database
 
+DROP DATABASE IF EXISTS "sequelize_auto_test";
+CREATE DATABASE "sequelize_auto_test";
+
 DROP TABLE IF EXISTS "OrderItem";
 DROP TABLE IF EXISTS "Product";
 DROP TABLE IF EXISTS "Supplier";

--- a/sqlite3.Dockerfile
+++ b/sqlite3.Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stable-slim
+
+RUN apt-get update && \
+	apt-get -yq --no-install-recommends install sqlite3=3.* && \
+	mkdir -p /usr/db
+
+WORKDIR /usr/db
+
+CMD truncate -s 0 northwind.sqlite && \
+  sqlite3 northwind.sqlite < sqlite-sample-model.sql && \
+  sqlite3 northwind.sqlite < sqlite-sample-data.sql


### PR DESCRIPTION
Adds Docker containers for supported database types to speed up testing.

Relates to: https://github.com/sequelize/sequelize-auto/issues/478

Outstanding issues: On boot the `mssql` container complains about errors, seems that the model script might have problems?