### PR TITLE
added check for duplicate aliases

### DIFF
--- a/src/auto-relater.ts
+++ b/src/auto-relater.ts
@@ -12,6 +12,7 @@ export class AutoRelater {
   singularize: boolean;
   relations: Relation[];
   private usedChildNames: Set<string>;
+  private usedChildPropNames: Set<string>;
 
   constructor(options: AutoOptions) {
     this.caseModel = options.caseModel || 'o';
@@ -21,6 +22,7 @@ export class AutoRelater {
     this.tableData = new TableData();
     this.relations = [];
     this.usedChildNames = new Set();
+    this.usedChildPropNames = new Set();
   }
 
   /** Create Relations from the foreign keys, and add to TableData */
@@ -77,6 +79,11 @@ export class AutoRelater {
         const otherModel = recase(this.caseModel, otherKey.foreignSources.target_table as string, this.singularize);
         const otherProp = this.getAlias(otherKey.source_column, otherKey.foreignSources.target_table as string, otherKey.foreignSources.source_table as string, true);
         const otherId = recase(this.caseProp, otherKey.source_column);
+        let childProp = pluralize(otherProp);
+        if (this.usedChildPropNames.has(childProp)) {
+          childProp = childProp + '_' + modelName;
+        }
+        this.usedChildPropNames.add(childProp)
 
         this.relations.push({
           parentId: sourceProp,
@@ -84,7 +91,7 @@ export class AutoRelater {
           parentProp: pluralize(alias),
           parentTable: qNameJoin(spec.foreignSources.target_schema || schema, spec.foreignSources.target_table),
           childModel: otherModel,
-          childProp: pluralize(otherProp),
+          childProp,
           childTable: qNameJoin(otherKey.foreignSources.target_schema || schema, otherKey.foreignSources.target_table),
           childId: otherId,
           joinModel: modelName,


### PR DESCRIPTION
Hi there. I was using sequelize-auto for one of my projects which had the same parent model & same key for many to many relations to multiple models. Which as a result was generating the same aliases for multiple relations. Hence the error: `You have used the alias <alias_name> in two separate relations`. 

This change tracks all the aliases been used, and if an alias is being used for the second time, it attaches the through model name to the alias.