### PR TITLE
Es modules with "define" syntax instead of classes

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -66,6 +66,12 @@ export class AutoGenerator {
       header += "export default class #TABLE# extends Model {\n";
       header += sp + "static init(sequelize, DataTypes) {\n";
       header += sp + "super.init({\n";
+    } else if (this.options.lang === 'esmd') {
+      // new: use define (as with es5), but with es6 modules:
+      header += "import _sequelize from 'sequelize';\n";
+      header += "const { Model, Sequelize } = _sequelize;\n\n"; // are those first two lines even needed?
+      header += "export default function(sequelize, DataTypes) {\n";
+      header += sp + "return sequelize.define('#TABLE#', {\n";
     } else {
       header += "const Sequelize = require('sequelize');\n";
       header += "module.exports = function(sequelize, DataTypes) {\n";

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export function qNameJoin(schema: string | undefined, table: string | undefined)
 }
 
 /** Language of output model files */
-export declare type LangOption = "es5" | "es6" | "esm" | "ts";
+export declare type LangOption = "es5" | "es6" | "esm" | "ts" | "esmd";
 
 /** "c" camelCase |
  * "l" lower_case |


### PR DESCRIPTION
Applying the same models to multiple databases at the same time causes problems when the class syntax is used that comes along with the "-l esm" option. So I added another option "-l esmd" which creates esm6 modules, but with the sequelize.define syntax instead of the class inhereitance syntax. (The options so far provided 3 out of four combination between import/require and class/define (es5, es6, esm); "esmd" provides the fourth one.)
Background: Since the init methods are static, applying the models to a second/third/... sequelize instance with the class syntax will change the sequelize-instance in all the previously initialized models. (Even when dynamic imports are used to "reload" the model files; javascript is too smart and does not load them again.)  This does not happen with the define syntax, since  there the models are only applied to the involved sequelize-instance.