### PR TITLE
Fix alias generation for similar column names involving singularization

### DIFF
--- a/src/auto-relater.ts
+++ b/src/auto-relater.ts
@@ -100,13 +100,20 @@ export class AutoRelater {
     if (name === fkFieldName || isM2M) {
       name = fkFieldName + "_" + modelName;
     }
+    
+    // singularize in case one column name is the singularized form of another column in the same model
+    let singleName = singularize(name);
     if (isM2M) {
-      if (this.usedChildNames.has(modelName + "." + name)) {
+      if (this.usedChildNames.has(modelName + "." + singleName)) {
         name = name + "_" + targetModel;
       }
-      this.usedChildNames.add(modelName + "." + name);
-    } else {
-      this.usedChildNames.add(targetModel + "." + name);
+      this.usedChildNames.add(modelName + "." + singularize(name));
+    }
+    else {
+      if (this.usedChildNames.has(targetModel + "." + singleName)){
+        name = name + "_" + modelName;
+      }
+      this.usedChildNames.add(targetModel + "." + singularize(name));
     }
     return recase(this.caseProp, name, true);
   }
@@ -115,10 +122,12 @@ export class AutoRelater {
   private getChildAlias(fkFieldName: string, modelName: string, targetModel: string) {
     let name = modelName;
     // usedChildNames prevents duplicate names in same model
-    if (this.usedChildNames.has(targetModel + "." + name)) {
+    if (this.usedChildNames.has(targetModel + "." + singularize(name))) {
       name = this.trimId(fkFieldName);
       name = name + "_" + modelName;
     }
+    // singularize in case one column name is the singularized form of another column in the same model
+    name = singularize(name);
     this.usedChildNames.add(targetModel + "." + name);
     return recase(this.caseProp, name, true);
   }


### PR DESCRIPTION
Thanks for making such a powerful tool!

We were running into an issue where one of our tables had a column named something like 
"tcs_id"
and another named 
"tc_id",
participating in two different relationships. 

`usedChildNames` checks for elements based on unmodified names; it gained entries for `abcd.tc` and `abcd.tcs`.
But then `getAlias` and `getChildAlias` return singularized versions via `recase`: both `tcs_id` and `tc_id` come out as `tc`. `addRelation` therefore pushed multiple relations with the same values for `parentProp` / `childProp`, leading to duplicate aliases.

To fix this, getAlias and getChildAlias now check for collisions with the _singularized_ version of their name. If such a collision is found, the expanded name is generated using the original, non-singularized version of the name. If a collision isn't found, then the singularized form is used to generate the new entry to `usedChildNames`.