### PR TITLE
Recase Alias Properties

### DIFF
--- a/src/auto-writer.ts
+++ b/src/auto-writer.ts
@@ -98,14 +98,16 @@ export class AutoWriter {
     const rels = this.relations;
     rels.forEach(rel => {
       if (rel.isM2M) {
-        const asprop = pluralize(rel.childProp);
+        const asprop = recase(this.options.caseFile, pluralize(rel.childProp));
         strBelongsToMany += `  ${rel.parentModel}.belongsToMany(${rel.childModel}, { as: '${asprop}', through: ${rel.joinModel}, foreignKey: "${rel.parentId}", otherKey: "${rel.childId}" });\n`;
       } else {
-        const bAlias = (this.options.noAlias && rel.parentModel.toLowerCase() === rel.parentProp.toLowerCase()) ? '' : `as: "${rel.parentProp}", `;
+        const asParentProp = recase(this.options.caseFile, rel.parentProp);
+        const bAlias = (this.options.noAlias && rel.parentModel.toLowerCase() === rel.parentProp.toLowerCase()) ? '' : `as: "${asParentProp}", `;
         strBelongs += `  ${rel.childModel}.belongsTo(${rel.parentModel}, { ${bAlias}foreignKey: "${rel.parentId}"});\n`;
 
         const hasRel = rel.isOne ? "hasOne" : "hasMany";
-        const hAlias = (this.options.noAlias && Utils.pluralize(rel.childModel.toLowerCase()) === rel.childProp.toLowerCase()) ? '' : `as: "${rel.childProp}", `;
+        const asChildProp = recase(this.options.caseFile, rel.childProp);
+        const hAlias = (this.options.noAlias && Utils.pluralize(rel.childModel.toLowerCase()) === rel.childProp.toLowerCase()) ? '' : `as: "${asChildProp}", `;
         strBelongs += `  ${rel.parentModel}.${hasRel}(${rel.childModel}, { ${hAlias}foreignKey: "${rel.parentId}"});\n`;
       }
     });


### PR DESCRIPTION
Alisa has issue. When table has underscore name name like :catalog_product_entity_media_gallery_value , catalog_product_entity_int

Alias has the same values:
```
CatalogProductRelation.belongsTo(CatalogProductEntity, { as: "child", foreignKey: "child_id"});
  CatalogProductEntity.hasMany(CatalogProductRelation, { as: "child_catalog_product_relations", foreignKey: "child_id"});
  CatalogProductSuperAttribute.belongsTo(CatalogProductEntity, { as: "product", foreignKey: "product_id"});
  CatalogProductEntity.hasMany(CatalogProductSuperAttribute, { as: "catalog_product_super_attributes", foreignKey: "product_id"});
```
than alias doesn't work you can use getcatalog_product_entity_media_gallery_value() function.

So you need recast to use File And Class Case from the input CLI parameters to generate aliases in the same case : 
```
CatalogProductRelation.belongsTo(CatalogProductEntity, { as: "Child", foreignKey: "child_id"});
  CatalogProductEntity.hasMany(CatalogProductRelation, { as: "ChildCatalogProductRelations", foreignKey: "child_id"});
  CatalogProductSuperAttribute.belongsTo(CatalogProductEntity, { as: "Product", foreignKey: "product_id"});
  CatalogProductEntity.hasMany(CatalogProductSuperAttribute, { as: "CatalogProductSuperAttributes", foreignKey: "product_id"});
  CatalogProductSuperLink.belongsTo(CatalogProductEntity, { as: "Product", foreignKey: "product_id"});
  CatalogProductEntity.hasMany(CatalogProductSuperLink, { as: "CatalogProductSuperLinks", foreignKey: "product_id"});
  CatalogProductSuperLink.belongsTo(CatalogProductEntity, { as: "Parent", foreignKey: "parent_id"});
```