### PR TITLE
Remove useless require from header

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -73,7 +73,6 @@ export class AutoGenerator {
       header += "export default function(sequelize, DataTypes) {\n";
       header += sp + "return sequelize.define('#TABLE#', {\n";
     } else {
-      header += "const Sequelize = require('sequelize');\n";
       header += "module.exports = function(sequelize, DataTypes) {\n";
       header += sp + "return sequelize.define('#TABLE#', {\n";
     }


### PR DESCRIPTION
# Remove the useless require from header

My `SequelizeAuto` config:
> not declare the `lang` arguments.
```js
    const auto = new SequelizeAuto(conn, '', '', {
      singularize: false,
      directory: '/tmp/model',
      tables: tables,
    });
```
then I got a error like this:

```bash
Cannot find module 'sequelize' from 'xxx.js'
```

In ES5 model, the `Sequelize` variable is unused, so I think it can be removed. 

