### PR TITLE
added typeOverrides option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -162,12 +162,12 @@ export interface AutoOptions {
   storage?: string;
   /** Tables to export (default all) */
   tables?: string[];
+  /** Override the types of generated typescript file */
+  typeOverrides?: TypeOverrides;
   /** Database username */
   username?: string;
   /** Whether to export views (default false) */
   views?: boolean;
-  /** Override the types of generated typescript file */
-  typeOverrides?: TypeOverrides;
 }
 
 export type TSField = { special: string[]; elementType: string; } & ColumnDescription;
@@ -210,13 +210,31 @@ export function recase(opt: CaseOption | undefined, val: string | null, singular
   return val;
 }
 
+/**
+ * @type Required. Name of the type
+ * @source Optional. File path of the type relative to file in the directory.
+ *         Leave undefined if overriding with primitive types
+ * @isDefault Optional. Whether the type is an export default
+ * @isOptional Optional. Whether to add ?
+ */
 export interface ColumnTypeOverride {
   type: string;
-  source: string;
-  isDefault: boolean;
+  source?: string;
+  isDefault?: boolean;
+  isOptional?: boolean;
 }
 export type TableTypeOverride = { [columnName: string]: ColumnTypeOverride | undefined };
 export type TableTypeOverrides = { [tableName: string]: TableTypeOverride | undefined }
+/**
+ * @tables {
+ *  roles: {
+ *   name: {
+ *     type: "RoleTypes",
+ *     source: "../RoleTypes"
+ *   }
+ *  }
+ * }
+ */
 export interface TypeOverrides {
   tables?: TableTypeOverrides;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,8 @@ export interface AutoOptions {
   username?: string;
   /** Whether to export views (default false) */
   views?: boolean;
+  /** Override the types of generated typescript file */
+  typeOverrides?: TypeOverrides;
 }
 
 export type TSField = { special: string[]; elementType: string; } & ColumnDescription;
@@ -208,3 +210,13 @@ export function recase(opt: CaseOption | undefined, val: string | null, singular
   return val;
 }
 
+export interface ColumnTypeOverride {
+  type: string;
+  source: string;
+  isDefault: boolean;
+}
+export type TableTypeOverride = { [columnName: string]: ColumnTypeOverride | undefined };
+export type TableTypeOverrides = { [tableName: string]: TableTypeOverride | undefined }
+export interface TypeOverrides {
+  tables?: TableTypeOverrides;
+}


### PR DESCRIPTION
Added option `typeOverrides`.
It allows overriding the field types of the generated class.
For my use case I had to change the type of the `roles` table column `name` to a custom enum type.
Current output
```
export interface RolesAttributes {
	name: string;
        description?: string;
}

export class Roles extends Model<RolesAttributes, RolesCreationAttributes> implements RolesAttributes {
	name!: string;
        description?: string;
}
```
New output
```
import { RoleNames } from '../RoleNames'; // adds import

export interface RolesAttributes {
	name: RoleNames; // changed type
        description?: string;
}

export class Roles extends Model<RolesAttributes, RolesCreationAttributes> implements RolesAttributes {
	name!: RoleNames;
        description?: string;
}
```
How to use
```
options
{
 typeOverrides: {
  tables: {
    roles: {
      name: {
        type: "RoleNames",
        source: "../RoleNames",
        isDefault: false,
        isOptional: false
    }
  }
 }
}
/*
 * @type Required. Name of the type
 * @source Optional. File path of the type relative to file in the directory. Leave undefined if overriding with primitive types
 * @isDefault Optional. Whether the type is an export default
 * @isOptional Optional. Whether to add ?
 * /
```



