### PR TITLE
Handle EXTRACT statements as default values for numeric fields

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -319,8 +319,13 @@ export class AutoGenerator {
             val_text = `[${val_text}]`;
 
           } else if (this.isNumber(field_type) || field_type.match(/^(json)/)) {
-            // remove () around mssql numeric values; don't quote numbers or json
-            val_text = defaultVal.replace(/[)(]/g, '');
+              // preserve as literal if this field is a function to extract a value from a timestamp
+              if (defaultVal.toLowerCase().indexOf('extract') === 0 || defaultVal.toLowerCase().indexOf('(extract') === 0) {
+                val_text = "Sequelize.Sequelize.literal('" + defaultVal + "')";
+              } else {
+                  // remove () around mssql numeric values; don't quote numbers or json
+                  val_text = defaultVal.replace(/[)(]/g, '');    
+              }
 
           } else if (field_type === 'uuid' && (defaultVal === 'gen_random_uuid()' || defaultVal === 'uuid_generate_v4()')) {
             val_text = "DataTypes.UUIDV4";

--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -332,7 +332,7 @@ export class AutoGenerator {
 
           } else if (this.isNumber(field_type) || field_type.match(/^(json)/)) {
               // preserve as literal if this field is a function to extract a value from a timestamp
-              if (defaultVal.toLowerCase().indexOf('extract') === 0 || defaultVal.toLowerCase().indexOf('(extract') === 0) {
+              if (defaultVal.toLowerCase().includes('extract')) {
                 val_text = "Sequelize.Sequelize.literal('" + defaultVal + "')";
               } else {
                   // remove () around mssql numeric values; don't quote numbers or json

--- a/src/auto-relater.ts
+++ b/src/auto-relater.ts
@@ -100,13 +100,20 @@ export class AutoRelater {
     if (name === fkFieldName || isM2M) {
       name = fkFieldName + "_" + modelName;
     }
+    
+    // singularize in case one column name is the singularized form of another column in the same model
+    let singleName = singularize(name);
     if (isM2M) {
-      if (this.usedChildNames.has(modelName + "." + name)) {
+      if (this.usedChildNames.has(modelName + "." + singleName)) {
         name = name + "_" + targetModel;
       }
-      this.usedChildNames.add(modelName + "." + name);
-    } else {
-      this.usedChildNames.add(targetModel + "." + name);
+      this.usedChildNames.add(modelName + "." + singularize(name));
+    }
+    else {
+      if (this.usedChildNames.has(targetModel + "." + singleName)){
+        name = name + "_" + modelName;
+      }
+      this.usedChildNames.add(targetModel + "." + singularize(name));
     }
     return recase(this.caseProp, name, true);
   }
@@ -115,10 +122,12 @@ export class AutoRelater {
   private getChildAlias(fkFieldName: string, modelName: string, targetModel: string) {
     let name = modelName;
     // usedChildNames prevents duplicate names in same model
-    if (this.usedChildNames.has(targetModel + "." + name)) {
+    if (this.usedChildNames.has(targetModel + "." + singularize(name))) {
       name = this.trimId(fkFieldName);
       name = name + "_" + modelName;
     }
+    // singularize in case one column name is the singularized form of another column in the same model
+    name = singularize(name);
     this.usedChildNames.add(targetModel + "." + name);
     return recase(this.caseProp, name, true);
   }


### PR DESCRIPTION
Hi again. 
We have a table with a column that stores a specific component of a timestamp. Its default value is something like `(EXTRACT( MICROSECOND FROM NOW(3)) / 1000)`. At present, `sequelize-auto` generates invalid JS/TS in its output:
```
<snip>
      defaultValue: extractmicrosecond from now3 \/ 1000,
<snip>
```
