### PR TITLE
Remove unused import

### DIFF
--- a/src/auto-writer.ts
+++ b/src/auto-writer.ts
@@ -118,7 +118,7 @@ export class AutoWriter {
 
   // create the TypeScript init-models file to load all the models into Sequelize
   private createTsInitString(tables: string[], assoc: string) {
-    let str = 'import type { Sequelize, Model } from "sequelize";\n';
+    let str = 'import type { Sequelize } from "sequelize";\n';
     const modelNames: string[] = [];
     // import statements
     tables.forEach(t => {


### PR DESCRIPTION
Removes unused `Model` import for typescript `init-model.ts` file generation. Hasn't been used since https://github.com/sequelize/sequelize-auto/issues/511 🙂 