### PR TITLE
Fix timestamps & paranoid field comparison

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -769,8 +769,8 @@ export class AutoGenerator {
     if (additional.timestamps === false) {
       return false;
     }
-    return ((!additional.createdAt && field.toLowerCase() === 'createdat') || additional.createdAt === field)
-      || ((!additional.updatedAt && field.toLowerCase() === 'updatedat') || additional.updatedAt === field);
+    return ((!additional.createdAt && recase('c', field) === 'createdAt') || additional.createdAt === field)
+      || ((!additional.updatedAt && recase('c', field) === 'updatedAt') || additional.updatedAt === field);
   }
 
   private isParanoidField(field: string) {
@@ -778,7 +778,7 @@ export class AutoGenerator {
     if (additional.timestamps === false || additional.paranoid === false) {
       return false;
     }
-    return ((!additional.deletedAt && field.toLowerCase() === 'deletedat') || additional.deletedAt === field);
+    return ((!additional.deletedAt && recase('c', field) === 'deletedAt') || additional.deletedAt === field);
   }
 
   private isIgnoredField(field: string) {


### PR DESCRIPTION
Hi there, currently the timestamp and paranoid fields are not working well when the model is using different casing than camel case. 

With setting `{ "timestamps": true, "underscored": true }`,  the fields names are compared to `createdat` / `updatedat` etc, but their field names are `created_at`, `updated_at`etc. This causes that fields are not being correctly recognized as timestamps / paranoids and their fields are included in the model definition.

Current implementation
```
// field = 'created_at'
field.toLowerCase() === 'createdat'  // --->  'created_at' !== 'createdat'
```

The change compares the field name recased to camel case with the corresponding camel case name
```
// field = 'created_at'
recase('c', field) === 'createdAt'  // ---> 'createdAt' === 'createdAt'
```