### PR TITLE
TS: Make timestamp fields optional for creation

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -592,7 +592,8 @@ export class AutoGenerator {
     const fields = _.keys(this.tables[table]);
     return fields.filter((field): boolean => {
       const fieldObj = this.tables[table][field];
-      return fieldObj.allowNull || (!!fieldObj.defaultValue || fieldObj.defaultValue === "") || fieldObj.primaryKey;
+      return fieldObj.allowNull || (!!fieldObj.defaultValue || fieldObj.defaultValue === "") || fieldObj.primaryKey
+        || this.isTimestampField(field);
     });
   }
 


### PR DESCRIPTION
Hi there, `timestamp` fields are created/updated by sequelize, even if they are defined as `NOT NULL` in the db, they are not required when creating an entity.