### PR TITLE
Fix reserved words dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "mkdirp": "^1.0.4",
+    "reserved-words": "^0.1.2",
     "yargs": "^16.2.0"
   },
   "peerDependencies": {
@@ -88,7 +89,6 @@
     "nyc": "^15.1.0",
     "pg": "^8.5.1",
     "pg-hstore": "^2.3.3",
-    "reserved-words": "^0.1.2",
     "rimraf": "^3.0.2",
     "sequelize": "^6.11",
     "sqlite3": "5.0.2",


### PR DESCRIPTION
`reserved-words` is being used in published code but it's defined as `devDependency`. It should be either `dependency` or at least `peerDependency`. My project doesn't use it and sequelize-auto ends with an error 

```
Error: Cannot find module 'reserved-words'
Require stack:
- node_modules/sequelize-auto/lib/types.js
- node_modules/sequelize-auto/lib/auto-builder.js
- node_modules/sequelize-auto/lib/auto.js
- node_modules/sequelize-auto/index.js
- node_modules/sequelize-auto/bin/sequelize-auto
```