### PR TITLE
Detect default values that are functions with parameters

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -366,7 +366,7 @@ export class AutoGenerator {
             val_text = "Sequelize.Sequelize.fn('" + defaultVal.replace(/\(\)$/g, "") + "')";
 
           } else if (this.isNumber(field_type)) {
-            if (defaultVal.match(/\(\)/g)) {
+            if (defaultVal.match(/\([\w ]*\)/g)) {
               // assume it's a server function if it contains parens
               val_text = "Sequelize.Sequelize.literal('" + defaultVal + "')";
             } else {
@@ -374,7 +374,7 @@ export class AutoGenerator {
               val_text = defaultVal;
             }
 
-          } else if (defaultVal.match(/\(\)/g)) {
+          } else if (defaultVal.match(/\([\w ]*\)/g)) {
             // embedded function, pass as literal
             val_text = "Sequelize.Sequelize.literal('" + defaultVal + "')";
 


### PR DESCRIPTION
Hi. Thanks again for all your work on this.
It looks like the changes in 0.8.5 didn't quite resolve issue #548 :
We have a column with default value `(EXTRACT( MICROSECOND FROM NOW(3)) / 1000)`. Sequelize-auto currently generates invalid JS/TS in its output (though much nicer than before):

```
<snip>
      type: DataTypes.INTEGER,
      allowNull: false,
      defaultValue: extract(microsecond from now(3)) \/ 1000,
<snip>
```

This stems from line 369 in auto-generator.js:
```
if (defaultVal.match(/\(\)/g)) {
```
which only matches parentheses with nothing between them. This PR just changes the regex to `/\([\w ]*\)/g` so that it matches on parentheses with alphanumeric characters and/or spaces between them, and an equivalent change on line 377.

It may be appropriate to use an even more permissive regex - for example, `/\([\w ,]*\)/g` would also match functions with multiple arguments. I'm not familiar enough with the functions of the different RDBMSs that Sequelize supports to devise the ideal regex, but this adjustment should add functionality without breaking anything.
