### PR TITLE
Allow optional fields to be null

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -698,7 +698,13 @@ export class AutoGenerator {
       if (!this.options.skipFields || !this.options.skipFields.includes(field)){
         const name = this.quoteName(recase(this.options.caseProp, field));
         const isOptional = this.getTypeScriptFieldOptional(table, field);
-        str += `${sp}${name}${isOptional ? '?' : notNull}: ${this.getTypeScriptType(table, field)};\n`;
+        str += `${sp}${name}${isOptional ? '?' : notNull}: ${this.getTypeScriptType(table, field)}`;
+
+        if (isOptional) {
+          str += ' | null'
+        }
+
+        str += ';\n'
       }
     });
     return str;


### PR DESCRIPTION
Hi there, currently the fields that are nullable are only noted as `?`, which allows them to be omitted or `undefined`. This however doesn't allow them to be set `null` explicitly.

This is needed mainly when updating to set a field to `null`. Omitting the field causes no change, passing undefined throws an error in sequelize.

We should be able to call `model.update({ name: null })`