### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ const auto = new SequelizeAuto('database', 'user', 'pass', {
     additional: {
         timestamps: false
         // ...options added to each model
+        // If you want to add createdAt and updatedAt timestamps to the model, also declare createAt and updatedAt like this. Otherwise the createdAt and updatedAt timestamps will not be automatically added to the model
+        // timestamps: true, createAt: true, updatedAt: true
     },
     tables: ['table1', 'table2', 'myschema.table3'] // use all tables, if omitted
     //...


### PR DESCRIPTION
Hi, the sequelize documentation states that timestamps is used to automatically add createdAt and updatedAt timestamps to the model
![image](https://user-images.githubusercontent.com/29145552/150264521-eb1af522-492f-491f-8a57-d69b93e5cbc9.png)

However I am setting timestamps: true in using but I cannot automatically add createdAt and updatedAt timestamps to the model

The reason is that the code here ignores createAt, and updateAt, and the documentation needs to be supplemented, which is different from the official documentation
![image](https://user-images.githubusercontent.com/29145552/150264910-c24175c3-52f7-4250-96f8-0dfcc12ab5a7.png)

