### PR TITLE
fix: correct typescript model gen issue #596 #597

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -113,12 +113,12 @@ export class AutoGenerator {
 
         if (creationOptionalFields.length) {
           str += `export type #TABLE#OptionalAttributes = ${creationOptionalFields.map((k) => `"${recase(this.options.caseProp, k)}"`).join(' | ')};\n`;
-          str += "export type #TABLE#CreationAttributes = Optional<#TABLE#Attributes, #TABLE#OptionalAttributes>;\n\n";
+          str += "export type #TABLE#CreationAttributes = Omit<#TABLE#Attributes, #TABLE#OptionalAttributes>;\n\n";
         } else {
           str += "export type #TABLE#CreationAttributes = #TABLE#Attributes;\n\n";
         }
 
-        str += "export class #TABLE# extends Model<#TABLE#Attributes, #TABLE#CreationAttributes> implements #TABLE#Attributes {\n";
+        str += "export class #TABLE# extends Model<#TABLE#Attributes | #TABLE#CreationAttributes> implements #TABLE#Attributes {\n";
         str += this.addTypeScriptFields(table, false);
         str += "\n" + associations.str;
         str += "\n" + this.space[1] + "static initModel(sequelize: Sequelize.Sequelize): typeof #TABLE# {\n";


### PR DESCRIPTION
**Purpose:**
- The TS models generated have problem with optional attributes; There were issues while compiling too.

Fixes #596 #597 

**sequelize:** v6.6.5
models were generated against a _postgres_ database
TS compiler was using standard ES6 rules