### PR TITLE
fix: #596 #625 createdAt, updatedAt, and deletedAt are missing in ts definition

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -235,12 +235,6 @@ export class AutoGenerator {
   // Create a string containing field attributes (type, defaultValue, etc.)
   private addField(table: string, field: string): string {
 
-    // ignore Sequelize standard fields
-    const additional = this.options.additional;
-    if (additional && (additional.timestamps !== false) && (this.isTimestampField(field) || this.isParanoidField(field))) {
-      return '';
-    }
-
     if (this.isIgnoredField(field)) {
       return '';
     }


### PR DESCRIPTION
Fix #625 & #596
`createdAt` and `updatedAt` fields are missing when enable option `timestamp: true`