### PR TITLE
fix quote for default value

### DIFF
--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -376,7 +376,7 @@ export class AutoGenerator {
 
           } else if (defaultVal.match(/\(\)/g)) {
             // embedded function, pass as literal
-              val_text = 'Sequelize.Sequelize.literal("' + defaultVal + '")';
+            val_text = 'Sequelize.Sequelize.literal("' + defaultVal + '")';
 
           } else if (field_type.indexOf('date') === 0 || field_type.indexOf('timestamp') === 0) {
             if (_.includes(['current_timestamp', 'current_date', 'current_time', 'localtime', 'localtimestamp'], defaultVal.toLowerCase())) {


### PR DESCRIPTION
I'm sorry and thank you for your sharing.

This PR is about default value.

I have field that uses single quote in default clause,

```
  `id` binary(16) NOT NULL DEFAULT unhex(replace(uuid(),'-','')) COMMENT 'identifier',
```

then it generates 

```
      defaultValue: Sequelize.Sequelize.literal('unhex(replace(uuid(),'-',''))'),
```

then it causes error.

I've tried `DEFAULT unhex(replace(uuid(),"-","")) `, but MariaDB converts `"` to `'`.

I always think thanking you when I use sequelize-auto, please consider this.

Best regards.
